### PR TITLE
Refresh glassmorphism styling for the app shell

### DIFF
--- a/app/assets/stylesheets/themes.css
+++ b/app/assets/stylesheets/themes.css
@@ -2,45 +2,59 @@
 /* Premium Admin Design Tokens: Light (:root) + Dark ([data-theme="ink"]) */
 :root {
   /* Neutrals */
-  --bg: #f5f7fa; /* page background */
+  --bg: #edf1ff; /* page background */
   --surface: #ffffff; /* cards, panels */
-  --surface-border: #e0e6ee; /* separators */
-  --text: #1d2733;
-  --text-muted: #637385;
+  --surface-border: #d8def4; /* separators */
+  --text: #121c3b;
+  --text-muted: #5f6f95;
 
-  /* Accent (Sapphire → Cyan) */
-  --primary: #2563eb;
-  --primary-hover: #1d4ed8;
-  --ring: #3b82f6;
-  --accent-cyan: #06b6d4;
-  --gradient-accent: linear-gradient(90deg, var(--primary) 0%, var(--accent-cyan) 100%);
+  /* Accent (Indigo → Aqua) */
+  --primary: #4f46e5;
+  --primary-hover: #4338ca;
+  --ring: #6366f1;
+  --accent-cyan: #22d3ee;
+  --gradient-accent: linear-gradient(115deg, var(--primary) 0%, #38bdf8 100%);
+
+  /* Ambient & Glass */
+  --bg-gradient: radial-gradient(65% 65% at 0% 0%, rgba(99,102,241,0.22) 0%, transparent 60%),
+                  radial-gradient(45% 55% at 100% 0%, rgba(20,184,166,0.18) 0%, transparent 70%);
+  --bg-spot: radial-gradient(70% 70% at 50% 105%, rgba(79,70,229,0.16) 0%, transparent 75%);
+  --glass: rgba(255,255,255,0.78);
+  --glass-border: rgba(226,232,255,0.8);
+  --glass-shadow: 0 24px 65px -35px rgba(15,23,42,0.45);
 
   /* Semantic */
-  --success-bg: #ecfdf5; --success-fg: #047857; --success-brd: #89e6c0;
-  --error-bg: #fef2f2; --error-fg: #b91c1c; --error-brd: #f6b1b1;
-  --muted-bg: #f1f5f9; --muted-fg: #4b5b6c; --muted-brd: #d7e1ea;
+  --success-bg: #ecfdf5; --success-fg: #047857; --success-brd: #a7f3d0;
+  --error-bg: #fef2f2; --error-fg: #b91c1c; --error-brd: #fecaca;
+  --muted-bg: #f5f7ff; --muted-fg: #53608a; --muted-brd: #dfe4fb;
 
   /* Elevation & Motion */
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05), 0 0 0 1px rgba(0,0,0,0.03);
-  --shadow: 0 4px 14px -2px rgba(0,0,0,0.12), 0 2px 6px -2px rgba(0,0,0,0.06);
-  --transition: 180ms cubic-bezier(.45,.2,.15,1);
+  --shadow-sm: 0 16px 45px -28px rgba(15,23,42,0.5), 0 0 0 1px rgba(79,70,229,0.04);
+  --shadow: 0 35px 90px -45px rgba(15,23,42,0.55), 0 25px 60px -50px rgba(20,20,60,0.4);
+  --transition: 220ms cubic-bezier(.34,.2,.15,1);
 }
 
 [data-theme="ink"] {
-  --bg: #0c1116;
-  --surface: #161e23;
-  --surface-border: #26333f;
-  --text: #f1f5f9;
-  --text-muted: #8fa2b5;
-  --primary: #3b82f6;
-  --primary-hover: #2563eb;
-  --ring: #1d4ed8;
-  --accent-cyan: #06b6d4;
-  --gradient-accent: linear-gradient(90deg, var(--primary) 0%, var(--accent-cyan) 100%);
-  --success-bg: #064e3b; --success-fg: #34d399; --success-brd: #059669;
+  --bg: #050819;
+  --surface: #0f172a;
+  --surface-border: #1f2a3f;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --primary: #818cf8;
+  --primary-hover: #6366f1;
+  --ring: #6366f1;
+  --accent-cyan: #38bdf8;
+  --gradient-accent: linear-gradient(115deg, var(--primary) 0%, #22d3ee 100%);
+  --bg-gradient: radial-gradient(60% 60% at 0% 0%, rgba(99,102,241,0.22) 0%, transparent 70%),
+                 radial-gradient(55% 65% at 100% 0%, rgba(8,145,178,0.24) 0%, transparent 80%);
+  --bg-spot: radial-gradient(75% 75% at 50% 105%, rgba(59,130,246,0.22) 0%, transparent 70%);
+  --glass: rgba(15,23,42,0.72);
+  --glass-border: rgba(148,163,184,0.16);
+  --glass-shadow: 0 30px 95px -55px rgba(2,6,23,0.85);
+  --success-bg: #064e3b; --success-fg: #34d399; --success-brd: #0d9488;
   --error-bg: #3f1d20; --error-fg: #f87171; --error-brd: #dc2626;
-  --muted-bg: #19242d; --muted-fg: #92a5b7; --muted-brd: #2a3a48;
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.04);
-  --shadow: 0 8px 22px -8px rgba(0,0,0,0.7), 0 4px 10px -4px rgba(0,0,0,0.55);
-  --transition: 185ms cubic-bezier(.45,.2,.15,1);
+  --muted-bg: #142032; --muted-fg: #9aa7c3; --muted-brd: #22324a;
+  --shadow-sm: 0 20px 55px -45px rgba(2,6,23,0.9), 0 0 0 1px rgba(148,163,184,0.08);
+  --shadow: 0 40px 120px -60px rgba(2,6,23,0.95), 0 25px 65px -60px rgba(8,15,40,0.7);
+  --transition: 220ms cubic-bezier(.34,.2,.15,1);
 }

--- a/app/assets/stylesheets/ui.css
+++ b/app/assets/stylesheets/ui.css
@@ -1,120 +1,373 @@
 /* Premium Admin Component Layer (uses tokens from themes.css) */
-:root { --container: 60rem; }
+:root { --container: 64rem; }
 
 /* Base Layout */
-body { background: var(--bg); color: var(--text); -webkit-font-smoothing: antialiased; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
+  position: relative;
+  line-height: 1.55;
+  letter-spacing: -0.01em;
+  overflow-x: hidden;
+}
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -2;
+}
+body::before { background: var(--bg-gradient); opacity: 0.9; }
+body::after { background: var(--bg-spot); z-index: -3; }
 .container-page { max-width: var(--container); @apply mx-auto px-4; }
+.app-shell { min-height: 100vh; display: flex; flex-direction: column; }
+.page-main { flex: 1; padding: 3.5rem 0 4rem; position: relative; }
+.page-main__inner { display: flex; flex-direction: column; gap: 1.75rem; }
+.site-footer { padding-bottom: 2.5rem; }
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.75rem 0 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  border-top: 1px solid color-mix(in srgb, var(--surface-border) 72%, transparent);
+}
 
 /* Global Motion & Focus */
-* { transition: color var(--transition), background-color var(--transition), border-color var(--transition), box-shadow var(--transition), transform var(--transition), opacity var(--transition); }
-:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--ring); border-radius: .5rem; }
-@media (prefers-reduced-motion: reduce) { * { transition: none !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; } }
+* {
+  transition: color var(--transition), background-color var(--transition), border-color var(--transition),
+              box-shadow var(--transition), transform var(--transition), opacity var(--transition);
+}
+:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--ring); border-radius: .6rem; }
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
+}
 
 /* Top Bar */
-.topbar { background: color-mix(in oklab, var(--surface), transparent 10%); border-bottom:1px solid var(--surface-border); @apply w-full sticky top-0 z-50 backdrop-blur-sm px-4; }
-.topbar .container-page { display:flex; align-items:center; justify-content:space-between; gap:1.25rem; }
-.topbar nav { display:flex; align-items:center; gap:.75rem; margin-left:auto; }
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  padding: 1.75rem 0 1rem;
+  background: linear-gradient(to bottom, color-mix(in srgb, var(--bg) 82%, transparent) 0%, transparent 85%);
+  backdrop-filter: blur(22px);
+}
+.topbar .container-page { pointer-events: none; }
+.topbar-inner {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: 1.75rem;
+  background: var(--glass);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  backdrop-filter: blur(18px);
+}
+.topbar .nav { display: flex; align-items: center; gap: .65rem; margin-left: auto; }
 
-/* Brand (works if class omitted, fallback to first link) */
-.brand, .topbar > .container-page > a:first-child { font-weight:600; letter-spacing:-.5px; background:var(--gradient-accent); -webkit-background-clip:text; background-clip:text; color:transparent; text-decoration:none; white-space:nowrap; position:relative; }
-.brand:hover, .topbar > .container-page > a:first-child:hover { filter:brightness(1.05); }
+/* Brand */
+.brand-logo {
+  font-weight: 700;
+  letter-spacing: -0.6px;
+  font-size: 1rem;
+  text-decoration: none;
+  background: var(--gradient-accent);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+}
+.brand-logo::after {
+  content: "";
+  width: .5rem;
+  height: .5rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent-cyan) 60%, transparent);
+  box-shadow: 0 0 0 6px color-mix(in srgb, var(--accent-cyan) 20%, transparent);
+}
 
-/* Navigation Pills */
-.nav-link { position:relative; display:inline-flex; align-items:center; gap:.35rem; font-weight:500; font-size:.75rem; letter-spacing:.25px; line-height:1; padding:.55rem .85rem; border-radius:999px; color:var(--text-muted); text-decoration:none; backdrop-filter:blur(4px); }
-.nav-link:hover { color:var(--text); background:color-mix(in srgb,var(--muted-bg) 60%, transparent); }
-.nav-link:focus-visible { box-shadow:0 0 0 2px var(--ring); }
-.nav-link--active, .nav-link.active { color:var(--text); background:color-mix(in srgb,var(--muted-bg) 80%, transparent); box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--surface-border) 85%, transparent), 0 1px 2px rgba(0,0,0,.08); }
-.nav-link--active:hover, .nav-link.active:hover { background:color-mix(in srgb,var(--muted-bg) 70%, transparent); }
-/* Fallback styling if .nav-link class missing */
-.topbar nav a:not(.nav-link) { @apply inline-flex items-center; font-size:.75rem; padding:.5rem .7rem; border-radius:.6rem; color:var(--text-muted); text-decoration:none; }
-.topbar nav a:not(.nav-link):hover { color:var(--text); background:color-mix(in srgb,var(--muted-bg) 55%, transparent); }
-.topbar nav a.nav-link--active:not(.nav-link) { color:var(--text); background:color-mix(in srgb,var(--muted-bg) 70%, transparent); }
+/* Navigation */
+.nav-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  font-weight: 500;
+  font-size: .8rem;
+  padding: .6rem 1rem;
+  border-radius: 999px;
+  color: var(--text-muted);
+  text-decoration: none;
+  border: 1px solid transparent;
+  background: transparent;
+  box-shadow: 0 0 0 0 rgba(0,0,0,0);
+}
+.nav-link:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--muted-bg) 60%, transparent);
+  border-color: color-mix(in srgb, var(--surface-border) 55%, transparent);
+  box-shadow: 0 12px 30px -20px rgba(15,23,42,0.4);
+}
+.nav-link.is-active,
+.nav-link--active,
+.nav-link.active {
+  color: var(--text);
+  background: color-mix(in srgb, var(--muted-bg) 78%, transparent);
+  border-color: color-mix(in srgb, var(--surface-border) 65%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--surface-border) 45%, transparent),
+              0 14px 30px -22px rgba(15,23,42,0.45);
+}
+.nav-link--primary {
+  background: var(--gradient-accent);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 20px 45px -28px rgba(79,70,229,0.7);
+}
+.nav-link--primary:hover,
+.nav-link--primary.is-active {
+  color: #fff;
+  filter: brightness(1.05);
+  box-shadow: 0 26px 55px -28px rgba(79,70,229,0.75);
+}
+.nav-link--icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  justify-content: center;
+  border-color: color-mix(in srgb, var(--surface-border) 55%, transparent);
+  background: color-mix(in srgb, var(--muted-bg) 55%, transparent);
+  box-shadow: none;
+}
+.nav-link--icon:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--muted-bg) 70%, transparent);
+}
 
 /* Hero Strip */
-.hero { background:linear-gradient(140deg, color-mix(in oklab,var(--primary) 12%, transparent) 0%, color-mix(in oklab,var(--accent-cyan) 10%, transparent) 100%); @apply rounded-xl mb-6 relative; padding:1.5rem 1.75rem; display:flex; gap:1.5rem; align-items:flex-start; }
-.hero h1 { @apply text-xl font-semibold; letter-spacing:-.5px; margin:0 0 .35rem; }
-.hero p { @apply text-sm; margin:0; color:var(--text-muted); }
-.hero .toolbar { margin-left:auto; }
+.hero {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, color-mix(in oklab, var(--primary) 14%, transparent) 0%,
+                                      color-mix(in oklab, var(--accent-cyan) 12%, transparent) 100%);
+  @apply rounded-2xl mb-8;
+  padding: 1.75rem 2rem;
+  display: flex;
+  gap: 1.75rem;
+  align-items: flex-start;
+  box-shadow: var(--shadow-sm);
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255,255,255,0.18) 0%, transparent 60%);
+  mix-blend-mode: screen;
+}
+.hero h1 { @apply text-xl font-semibold; letter-spacing: -.6px; margin: 0 0 .5rem; }
+.hero p { @apply text-sm; margin: 0; color: color-mix(in srgb, #ffffff 20%, var(--text-muted)); }
+.hero .toolbar { margin-left: auto; position: relative; z-index: 1; }
 
 /* Toolbar */
-.toolbar { @apply flex flex-wrap items-center gap-2; min-height:2.25rem; }
+.toolbar { @apply flex flex-wrap items-center gap-2; min-height: 2.35rem; }
 
 /* Cards */
-.card { background:var(--surface); border:1px solid var(--surface-border); box-shadow:var(--shadow-sm); @apply rounded-2xl p-6; position:relative; }
-.card:hover { box-shadow:var(--shadow); }
-.card + .card { @apply mt-5; }
-.panel { background:var(--surface); border:1px solid var(--surface-border); box-shadow:var(--shadow-sm); @apply rounded-xl p-4; }
+.card {
+  position: relative;
+  background: color-mix(in srgb, var(--surface) 96%, rgba(255,255,255,0.75));
+  border: 1px solid color-mix(in srgb, var(--surface-border) 70%, transparent);
+  box-shadow: var(--shadow-sm);
+  @apply rounded-3xl p-7;
+}
+.card:hover { box-shadow: var(--shadow); transform: translateY(-2px); }
+.card + .card { @apply mt-6; }
+.panel {
+  background: color-mix(in srgb, var(--surface) 94%, rgba(255,255,255,0.7));
+  border: 1px solid color-mix(in srgb, var(--surface-border) 70%, transparent);
+  box-shadow: var(--shadow-sm);
+  @apply rounded-2xl p-5;
+}
 
 /* Buttons */
-.btn { @apply inline-flex items-center gap-2 font-medium text-sm rounded-xl select-none cursor-pointer; padding:.65rem 1rem; line-height:1.1; border:1px solid transparent; background:transparent; transform:translateY(0); }
-.btn:hover { transform:translateY(1px); }
-.btn:focus-visible { box-shadow:0 0 0 2px var(--ring); }
-.btn-primary { background:var(--primary); border-color:var(--primary); color:#fff; box-shadow:0 2px 4px -1px rgba(0,0,0,.15); }
-.btn-primary:hover { background:var(--primary-hover); }
-.btn-secondary { background:var(--surface); border:1px solid var(--surface-border); color:var(--text); }
-.btn-secondary:hover { background:var(--muted-bg); }
-.btn-ghost { background:transparent; border-color:transparent; color:var(--text-muted); }
-.btn-ghost:hover { color:var(--text); background:color-mix(in srgb,var(--muted-bg) 60%, transparent); }
-.btn[disabled], .btn:disabled { @apply opacity-50 cursor-not-allowed; transform:none; }
+.btn {
+  @apply inline-flex items-center gap-2 font-semibold text-sm rounded-full select-none cursor-pointer;
+  padding: .65rem 1.15rem;
+  line-height: 1.1;
+  border: 1px solid color-mix(in srgb, var(--surface-border) 60%, transparent);
+  background: transparent;
+  color: var(--text);
+  transform: translateY(0);
+}
+.btn:hover { transform: translateY(-1px); box-shadow: 0 18px 30px -24px rgba(15,23,42,0.55); }
+.btn:focus-visible { box-shadow: 0 0 0 2px var(--ring); }
+.btn-primary {
+  background: var(--gradient-accent);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 25px 50px -28px rgba(79,70,229,0.75);
+}
+.btn-primary:hover { filter: brightness(1.05); }
+.btn-secondary {
+  background: color-mix(in srgb, var(--muted-bg) 75%, transparent);
+  color: var(--text);
+}
+.btn-secondary:hover { background: color-mix(in srgb, var(--muted-bg) 85%, transparent); }
+.btn-ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-muted);
+}
+.btn-ghost:hover { color: var(--text); background: color-mix(in srgb, var(--muted-bg) 60%, transparent); }
+.btn[disabled], .btn:disabled { @apply opacity-50 cursor-not-allowed; transform: none; box-shadow: none; }
 
 /* Form Controls */
-.label { @apply block uppercase tracking-wide font-semibold text-[0.65rem] mb-1; color:var(--text-muted); }
-.input, .select, .textarea { background:var(--surface); border:1px solid var(--surface-border); color:var(--text); @apply w-full rounded-xl text-sm; padding:0.625rem 0.9rem; min-height:44px; line-height:1.2; }
-.input::placeholder, .textarea::placeholder { color:color-mix(in srgb,var(--text-muted) 75%, transparent); }
-.input:focus, .select:focus, .textarea:focus { border-color:var(--ring); box-shadow:0 0 0 2px var(--ring), 0 1px 0 0 rgba(0,0,0,.05); }
+.label { @apply block uppercase tracking-wide font-semibold text-[0.65rem] mb-1; color: var(--text-muted); letter-spacing: .14em; }
+.input,
+.select,
+.textarea {
+  background: color-mix(in srgb, var(--surface) 96%, rgba(255,255,255,0.65));
+  border: 1px solid color-mix(in srgb, var(--surface-border) 70%, transparent);
+  color: var(--text);
+  @apply w-full rounded-2xl text-sm;
+  padding: 0.7rem 1rem;
+  min-height: 44px;
+  line-height: 1.25;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.2);
+}
+.input::placeholder,
+.textarea::placeholder { color: color-mix(in srgb, var(--text-muted) 75%, transparent); }
+.input:focus,
+.select:focus,
+.textarea:focus { border-color: var(--ring); box-shadow: 0 0 0 2px var(--ring), 0 18px 35px -30px rgba(79,70,229,0.55); }
 
 /* Badges */
-.badge { @apply inline-flex items-center font-medium; font-size:10.5px; line-height:1; padding:.25rem .55rem; border-radius:999px; border:1px solid var(--muted-brd); background:var(--muted-bg); color:var(--muted-fg); letter-spacing:.25px; }
-.badge-success { background:var(--success-bg); color:var(--success-fg); border-color:var(--success-brd); }
-.badge-error { background:var(--error-bg); color:var(--error-fg); border-color:var(--error-brd); }
-.badge-muted { background:var(--muted-bg); color:var(--muted-fg); border-color:var(--muted-brd); }
+.badge {
+  @apply inline-flex items-center font-medium;
+  font-size: 11px;
+  line-height: 1;
+  padding: .3rem .6rem;
+  border-radius: 999px;
+  border: 1px solid var(--muted-brd);
+  background: var(--muted-bg);
+  color: var(--muted-fg);
+  letter-spacing: .3px;
+  text-transform: uppercase;
+}
+.badge-success { background: var(--success-bg); color: var(--success-fg); border-color: var(--success-brd); }
+.badge-error { background: var(--error-bg); color: var(--error-fg); border-color: var(--error-brd); }
+.badge-muted { background: var(--muted-bg); color: var(--muted-fg); border-color: var(--muted-brd); }
 
 /* Table */
-.table { @apply w-full text-sm; border-collapse:separate; border-spacing:0; }
-.table thead th { position:sticky; top:0; z-index:5; backdrop-filter:blur(6px); background:var(--muted-bg); color:var(--text-muted); @apply font-medium text-left; padding:.6rem .9rem; }
-.table tbody td { padding:.55rem .9rem; vertical-align:top; }
-.table tbody tr { border-top:1px solid var(--surface-border); }
-.table tbody tr:nth-child(even) { background:color-mix(in srgb,var(--muted-bg) 35%, transparent); }
-.table tbody tr:hover { background:color-mix(in srgb,var(--muted-bg) 55%, transparent); }
-.table tbody tr:last-child { border-bottom:1px solid var(--surface-border); }
+.table { @apply w-full text-sm; border-collapse: separate; border-spacing: 0; }
+.table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  backdrop-filter: blur(16px);
+  background: color-mix(in srgb, var(--surface) 88%, rgba(255,255,255,0.65));
+  color: var(--text-muted);
+  @apply font-medium text-left;
+  padding: .65rem 1rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-border) 60%, transparent);
+}
+.table tbody td { padding: .65rem 1rem; vertical-align: top; }
+.table tbody tr { border-top: 1px solid color-mix(in srgb, var(--surface-border) 65%, transparent); }
+.table tbody tr:nth-child(even) { background: color-mix(in srgb, var(--muted-bg) 35%, transparent); }
+.table tbody tr:hover { background: color-mix(in srgb, var(--muted-bg) 55%, transparent); }
+.table tbody tr:last-child { border-bottom: 1px solid color-mix(in srgb, var(--surface-border) 55%, transparent); }
+.table-wrap { max-height: 70vh; overflow: auto; border-radius: 1rem; box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--surface-border) 55%, transparent); }
 
 /* Flash Messages */
-.flash-ok, .flash-error { @apply rounded-xl text-sm font-medium; padding:.65rem 1rem; border:1px solid; }
-.flash-ok { background:var(--success-bg); color:var(--success-fg); border-color:var(--success-brd); }
-.flash-error { background:var(--error-bg); color:var(--error-fg); border-color:var(--error-brd); }
+.flash-stack { display: flex; flex-direction: column; gap: .85rem; }
+.flash,
+.flash-ok,
+.flash-error {
+  @apply rounded-2xl text-sm font-medium;
+  padding: .75rem 1.1rem;
+  border: 1px solid transparent;
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: blur(8px);
+}
+.flash,
+.flash-ok,
+.flash-error { background: color-mix(in srgb, var(--surface) 92%, rgba(255,255,255,0.6)); color: var(--text); }
+.flash--ok,
+.flash-ok { background: var(--success-bg); color: var(--success-fg); border-color: var(--success-brd); }
+.flash--error,
+.flash-error { background: var(--error-bg); color: var(--error-fg); border-color: var(--error-brd); }
 
 /* Icons */
-.icon { @apply inline-flex items-center justify-center leading-none; font-size:0.875rem; }
-.icon-sm { font-size:0.75rem; }
-.icon-xs { font-size:0.625rem; }
-.icon-muted { color:var(--text-muted); }
-.icon-primary { color:var(--primary); }
+.icon { @apply inline-flex items-center justify-center leading-none; font-size: 0.875rem; }
+.icon-sm { font-size: 0.8rem; }
+.icon-xs { font-size: 0.625rem; }
+.icon-muted { color: var(--text-muted); }
+.icon-primary { color: var(--primary); }
 
 /* Tooltip */
 .tooltip { @apply relative inline-flex items-center; }
-.tooltip .tip { @apply hidden absolute z-50 text-[11px] leading-snug rounded-lg px-3 py-2; width:15rem; left:50%; top:calc(100% + .5rem); transform:translateX(-50%); background:var(--surface); color:var(--text); border:1px solid var(--surface-border); box-shadow:0 6px 18px -6px rgba(0,0,0,.18); }
-.tooltip:hover .tip, .tooltip:focus-within .tip { @apply block; }
+.tooltip .tip {
+  @apply hidden absolute z-50 text-[11px] leading-snug rounded-lg px-3 py-2;
+  width: 15rem;
+  left: 50%;
+  top: calc(100% + .5rem);
+  transform: translateX(-50%);
+  background: color-mix(in srgb, var(--surface) 96%, rgba(255,255,255,0.75));
+  color: var(--text);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 60%, transparent);
+  box-shadow: 0 20px 40px -30px rgba(15,23,42,0.65);
+}
+.tooltip:hover .tip,
+.tooltip:focus-within .tip { @apply block; }
 
 /* Callout */
-.callout { background:linear-gradient(135deg, color-mix(in oklab,var(--muted-bg) 95%, transparent) 0%, color-mix(in oklab,var(--muted-bg) 75%, transparent) 100%); border:1px solid var(--muted-brd); color:var(--muted-fg); @apply rounded-xl px-4 py-3 text-sm flex gap-3 items-start; }
-.callout .icon { font-size:.7rem; color:var(--primary); margin-top:2px; }
-
-/* Panel (compact variant already defined above as .panel) */
+.callout {
+  background: linear-gradient(135deg, color-mix(in oklab, var(--muted-bg) 95%, transparent) 0%,
+                                     color-mix(in oklab, var(--muted-bg) 70%, transparent) 100%);
+  border: 1px solid var(--muted-brd);
+  color: var(--muted-fg);
+  @apply rounded-2xl px-5 py-4 text-sm flex gap-3 items-start;
+}
+.callout .icon { font-size: .7rem; color: var(--primary); margin-top: 2px; }
 
 /* Skeleton Loader */
-@keyframes skeleton-shimmer { 0% { background-position:-200% 0; } 100% { background-position:200% 0; } }
-.skeleton { position:relative; overflow:hidden; border-radius:.5rem; background:linear-gradient(110deg, color-mix(in srgb,var(--muted-bg) 96%, transparent) 25%, color-mix(in srgb,var(--muted-bg) 86%, transparent) 37%, color-mix(in srgb,var(--muted-bg) 96%, transparent) 63%); background-size:200% 100%; animation:skeleton-shimmer 1.3s linear infinite; }
+@keyframes skeleton-shimmer { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  border-radius: .75rem;
+  background: linear-gradient(110deg,
+              color-mix(in srgb, var(--muted-bg) 96%, transparent) 25%,
+              color-mix(in srgb, var(--muted-bg) 86%, transparent) 37%,
+              color-mix(in srgb, var(--muted-bg) 96%, transparent) 63%);
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.3s linear infinite;
+}
 
 /* Utilities */
-.muted { color:var(--text-muted); }
+.muted { color: var(--text-muted); }
 
 /* Responsive */
-@media (max-width:640px) { .card { @apply p-5; } .hero { padding:1.25rem 1.25rem; flex-direction:column; } .container-page { @apply px-3; } .toolbar { @apply gap-1; } }
+@media (max-width: 768px) {
+  .topbar-inner { padding: 0.75rem 1rem; border-radius: 1.5rem; }
+  .nav-link { padding: .55rem .85rem; font-size: .78rem; }
+  .nav { gap: .5rem; }
+  .card { @apply p-6; }
+  .container-page { @apply px-3; }
+  .footer-inner { flex-direction: column; align-items: flex-start; }
+}
 
-/* Scrollable table wrapper with sticky header */
-.table-wrap { max-height: 70vh; overflow: auto; border-radius: 0.75rem; }
-.table thead th {
-    position: sticky; top: 0; z-index: 10;
-    background: var(--surface);
-    box-shadow: 0 1px 0 var(--surface-border);
+@media (max-width: 640px) {
+  .hero { padding: 1.35rem 1.4rem; flex-direction: column; }
+  .toolbar { @apply gap-1; }
+  .page-main { padding: 2.5rem 0 3rem; }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,10 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
+
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
@@ -26,41 +30,49 @@
 
   <body class="min-h-screen" data-controller="theme">
   <header class="topbar">
-    <div class="container-page h-14 flex items-center justify-between">
-      <a href="/" class="brand-logo text-base font-semibold tracking-tight bg-gradient-to-r from-violet-500 via-fuchsia-500 to-pink-500 bg-clip-text text-transparent">
-        Adyen Recon
-      </a>
-      <nav class="nav items-center gap-1">
-        <%= link_to "Uploads", report_files_path, class: ["nav-link", ("active" if current_page?(report_files_path))] %>
-        <%= link_to "Exports", exports_path, class: ["nav-link", ("active" if current_page?(exports_path))] %>
-        <%= link_to "New Export", new_export_path, class: ["nav-link", ("active" if current_page?(new_export_path))] %>
-        <%= link_to "Mapping", edit_mapping_profile_path, class: ["nav-link", ("active" if current_page?(edit_mapping_profile_path))] %>
-        <%= link_to "Reconciliation", reconciliations_path, class: "px-3 py-2 rounded-xl hover:bg-slate-100 nav-link" %>
-        <button type="button" class="nav-link" data-action="theme#toggle" aria-label="Toggle theme">
-          <i class="fa fa-moon icon-sm" data-theme-target="icon"></i>
-        </button>
-      </nav>
+    <div class="container-page px-4">
+      <div class="topbar-inner">
+        <a href="/" class="brand-logo">
+          Adyen Recon
+        </a>
+        <nav class="nav">
+          <%= link_to "Uploads", report_files_path, class: ["nav-link", ("is-active" if current_page?(report_files_path))] %>
+          <%= link_to "Exports", exports_path, class: ["nav-link", ("is-active" if current_page?(exports_path))] %>
+          <%= link_to "New Export", new_export_path, class: ["nav-link", ("is-active" if current_page?(new_export_path))] %>
+          <%= link_to "Mapping", edit_mapping_profile_path, class: ["nav-link", ("is-active" if current_page?(edit_mapping_profile_path))] %>
+          <%= link_to "Reconciliation", reconciliations_path, class: ["nav-link", "nav-link--primary", ("is-active" if current_page?(reconciliations_path))] %>
+          <button type="button" class="nav-link nav-link--icon" data-action="theme#toggle" aria-label="Toggle theme">
+            <i class="fa fa-moon icon-sm" data-theme-target="icon"></i>
+          </button>
+        </nav>
+      </div>
     </div>
   </header>
 
   <div class="app-shell">
-    <div class="container-page px-4 pt-4 space-y-2">
-      <% if notice.present? %>
-        <div class="flash-ok"><%= notice %></div>
-      <% end %>
-      <% if alert.present? %>
-        <div class="flash-error"><%= alert %></div>
-      <% end %>
-    </div>
+    <main class="page-main">
+      <div class="page-main__inner container-page px-4">
+        <% if notice.present? || alert.present? %>
+          <div class="flash-stack">
+            <% if notice.present? %>
+              <div class="flash flash--ok"><%= notice %></div>
+            <% end %>
+            <% if alert.present? %>
+              <div class="flash flash--error"><%= alert %></div>
+            <% end %>
+          </div>
+        <% end %>
 
-    <main class="container-page px-4 py-6">
-      <%= yield %>
+        <%= yield %>
+      </div>
     </main>
 
     <footer class="site-footer">
-      <div class="container-page px-4 py-6 text-xs text-slate-500 flex items-center justify-between">
-        <span>© <%= Time.current.year %> Adyen Recon</span>
-        <span class="muted">Reconciliation Suite</span>
+      <div class="container-page px-4">
+        <div class="footer-inner">
+          <span>© <%= Time.current.year %> Adyen Recon</span>
+          <span class="muted">Reconciliation Suite</span>
+        </div>
       </div>
     </footer>
   </div>


### PR DESCRIPTION
## Summary
- load the Inter typeface and rebuild the application shell with a glass navigation bar, updated flash stack, and structured footer
- retune the light and dark design tokens with an indigo-to-aqua palette plus gradient and glass variables for ambient backgrounds
- restyle the shared UI layer (cards, buttons, tables, hero, etc.) to deliver the requested fresh, modern appearance

## Testing
- bin/rails test *(fails: missing gems in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cda59a55088321b029477bcf40d14d