### PR TITLE
Refresh UI styling across app

### DIFF
--- a/app/assets/stylesheets/themes.css
+++ b/app/assets/stylesheets/themes.css
@@ -1,46 +1,58 @@
-/* Using application.css bundle; application.tailwind.css imports tailwind + themes + ui */
-/* Premium Admin Design Tokens: Light (:root) + Dark ([data-theme="ink"]) */
+/* Light (:root) and dark ([data-theme="ink"]) design tokens */
 :root {
-  /* Neutrals */
-  --bg: #f5f7fa; /* page background */
-  --surface: #ffffff; /* cards, panels */
-  --surface-border: #e0e6ee; /* separators */
-  --text: #1d2733;
-  --text-muted: #637385;
-
-  /* Accent (Sapphire → Cyan) */
-  --primary: #2563eb;
-  --primary-hover: #1d4ed8;
-  --ring: #3b82f6;
-  --accent-cyan: #06b6d4;
-  --gradient-accent: linear-gradient(90deg, var(--primary) 0%, var(--accent-cyan) 100%);
-
-  /* Semantic */
-  --success-bg: #ecfdf5; --success-fg: #047857; --success-brd: #89e6c0;
-  --error-bg: #fef2f2; --error-fg: #b91c1c; --error-brd: #f6b1b1;
-  --muted-bg: #f1f5f9; --muted-fg: #4b5b6c; --muted-brd: #d7e1ea;
-
-  /* Elevation & Motion */
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05), 0 0 0 1px rgba(0,0,0,0.03);
-  --shadow: 0 4px 14px -2px rgba(0,0,0,0.12), 0 2px 6px -2px rgba(0,0,0,0.06);
-  --transition: 180ms cubic-bezier(.45,.2,.15,1);
+  --bg: #f5f7fb;
+  --bg-muted: #e8ecff;
+  --surface: rgba(255, 255, 255, 0.88);
+  --surface-elevated: #ffffff;
+  --surface-border: rgba(148, 163, 184, 0.35);
+  --surface-border-strong: rgba(79, 70, 229, 0.25);
+  --text: #0f172a;
+  --text-muted: #566176;
+  --primary: #4f46e5;
+  --primary-hover: #4338ca;
+  --ring: rgba(99, 102, 241, 0.45);
+  --accent-cyan: #22d3ee;
+  --gradient-accent: linear-gradient(120deg, rgba(79,70,229,0.95) 0%, rgba(14,165,233,0.95) 100%);
+  --hero-gradient: linear-gradient(135deg, rgba(79,70,229,0.12) 0%, rgba(14,165,233,0.08) 100%);
+  --muted-bg: rgba(148, 163, 184, 0.18);
+  --muted-fg: #455168;
+  --muted-brd: rgba(148, 163, 184, 0.32);
+  --shadow-sm: 0 18px 40px -40px rgba(15, 23, 42, 0.4), 0 10px 24px -24px rgba(79, 70, 229, 0.35);
+  --shadow: 0 38px 80px -48px rgba(79, 70, 229, 0.55), 0 32px 70px -64px rgba(15, 23, 42, 0.5);
+  --transition: 190ms cubic-bezier(.4, .2, .2, 1);
+  --table-header-bg: rgba(79, 70, 229, 0.08);
+  --table-row-hover: rgba(15, 23, 42, 0.04);
+  --table-row-alt: rgba(148, 163, 184, 0.08);
+  --flash-ring: rgba(15, 23, 42, 0.08);
+  --success-bg: #ecfdf5; --success-fg: #047857; --success-brd: rgba(16, 185, 129, 0.35);
+  --error-bg: #fef2f2; --error-fg: #b91c1c; --error-brd: rgba(248, 113, 113, 0.35);
 }
 
 [data-theme="ink"] {
-  --bg: #0c1116;
-  --surface: #161e23;
-  --surface-border: #26333f;
-  --text: #f1f5f9;
-  --text-muted: #8fa2b5;
-  --primary: #3b82f6;
-  --primary-hover: #2563eb;
-  --ring: #1d4ed8;
-  --accent-cyan: #06b6d4;
-  --gradient-accent: linear-gradient(90deg, var(--primary) 0%, var(--accent-cyan) 100%);
-  --success-bg: #064e3b; --success-fg: #34d399; --success-brd: #059669;
-  --error-bg: #3f1d20; --error-fg: #f87171; --error-brd: #dc2626;
-  --muted-bg: #19242d; --muted-fg: #92a5b7; --muted-brd: #2a3a48;
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.04);
-  --shadow: 0 8px 22px -8px rgba(0,0,0,0.7), 0 4px 10px -4px rgba(0,0,0,0.55);
-  --transition: 185ms cubic-bezier(.45,.2,.15,1);
+  --bg: #04070f;
+  --bg-muted: #0f172a;
+  --surface: rgba(15, 23, 42, 0.82);
+  --surface-elevated: rgba(15, 23, 42, 0.96);
+  --surface-border: rgba(148, 163, 184, 0.18);
+  --surface-border-strong: rgba(129, 140, 248, 0.32);
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --primary: #6366f1;
+  --primary-hover: #4f46e5;
+  --ring: rgba(129, 140, 248, 0.55);
+  --accent-cyan: #22d3ee;
+  --gradient-accent: linear-gradient(120deg, rgba(99,102,241,0.95) 0%, rgba(45,212,191,0.95) 100%);
+  --hero-gradient: linear-gradient(135deg, rgba(99,102,241,0.26) 0%, rgba(45,212,191,0.14) 100%);
+  --muted-bg: rgba(148, 163, 184, 0.12);
+  --muted-fg: #cbd5f5;
+  --muted-brd: rgba(148, 163, 184, 0.28);
+  --shadow-sm: 0 24px 60px -45px rgba(99, 102, 241, 0.55), 0 15px 40px -35px rgba(15, 23, 42, 0.85);
+  --shadow: 0 42px 95px -50px rgba(99, 102, 241, 0.7), 0 45px 120px -60px rgba(8, 11, 19, 0.85);
+  --transition: 195ms cubic-bezier(.36, .2, .2, 1);
+  --table-header-bg: rgba(99, 102, 241, 0.12);
+  --table-row-hover: rgba(45, 55, 72, 0.45);
+  --table-row-alt: rgba(17, 24, 39, 0.62);
+  --flash-ring: rgba(99, 102, 241, 0.35);
+  --success-bg: rgba(22, 163, 74, 0.16); --success-fg: #4ade80; --success-brd: rgba(74, 222, 128, 0.3);
+  --error-bg: rgba(239, 68, 68, 0.14); --error-fg: #fca5a5; --error-brd: rgba(239, 68, 68, 0.35);
 }

--- a/app/assets/stylesheets/ui.css
+++ b/app/assets/stylesheets/ui.css
@@ -1,120 +1,433 @@
-/* Premium Admin Component Layer (uses tokens from themes.css) */
-:root { --container: 60rem; }
+/* Modern workspace UI built on Tailwind tokens */
+:root { --container: 72rem; }
 
-/* Base Layout */
-body { background: var(--bg); color: var(--text); -webkit-font-smoothing: antialiased; }
-.container-page { max-width: var(--container); @apply mx-auto px-4; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Inter", "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(120% 120% at 0% 0%, color-mix(in oklab, var(--accent-cyan) 26%, transparent) 0%, transparent 55%),
+              radial-gradient(110% 110% at 100% 0%, color-mix(in oklab, var(--primary) 30%, transparent) 0%, transparent 60%);
+  opacity: .65;
+  pointer-events: none;
+  z-index: -2;
+}
 
-/* Global Motion & Focus */
-* { transition: color var(--transition), background-color var(--transition), border-color var(--transition), box-shadow var(--transition), transform var(--transition), opacity var(--transition); }
-:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--ring); border-radius: .5rem; }
-@media (prefers-reduced-motion: reduce) { * { transition: none !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; } }
+.app-surface {
+  position: relative;
+  z-index: 0;
+}
 
-/* Top Bar */
-.topbar { background: color-mix(in oklab, var(--surface), transparent 10%); border-bottom:1px solid var(--surface-border); @apply w-full sticky top-0 z-50 backdrop-blur-sm px-4; }
-.topbar .container-page { display:flex; align-items:center; justify-content:space-between; gap:1.25rem; }
-.topbar nav { display:flex; align-items:center; gap:.75rem; margin-left:auto; }
+.container-page {
+  max-width: var(--container);
+  @apply mx-auto w-full;
+}
 
-/* Brand (works if class omitted, fallback to first link) */
-.brand, .topbar > .container-page > a:first-child { font-weight:600; letter-spacing:-.5px; background:var(--gradient-accent); -webkit-background-clip:text; background-clip:text; color:transparent; text-decoration:none; white-space:nowrap; position:relative; }
-.brand:hover, .topbar > .container-page > a:first-child:hover { filter:brightness(1.05); }
+* {
+  transition: color var(--transition),
+              background-color var(--transition),
+              border-color var(--transition),
+              box-shadow var(--transition),
+              transform var(--transition),
+              opacity var(--transition);
+}
 
-/* Navigation Pills */
-.nav-link { position:relative; display:inline-flex; align-items:center; gap:.35rem; font-weight:500; font-size:.75rem; letter-spacing:.25px; line-height:1; padding:.55rem .85rem; border-radius:999px; color:var(--text-muted); text-decoration:none; backdrop-filter:blur(4px); }
-.nav-link:hover { color:var(--text); background:color-mix(in srgb,var(--muted-bg) 60%, transparent); }
-.nav-link:focus-visible { box-shadow:0 0 0 2px var(--ring); }
-.nav-link--active, .nav-link.active { color:var(--text); background:color-mix(in srgb,var(--muted-bg) 80%, transparent); box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--surface-border) 85%, transparent), 0 1px 2px rgba(0,0,0,.08); }
-.nav-link--active:hover, .nav-link.active:hover { background:color-mix(in srgb,var(--muted-bg) 70%, transparent); }
-/* Fallback styling if .nav-link class missing */
-.topbar nav a:not(.nav-link) { @apply inline-flex items-center; font-size:.75rem; padding:.5rem .7rem; border-radius:.6rem; color:var(--text-muted); text-decoration:none; }
-.topbar nav a:not(.nav-link):hover { color:var(--text); background:color-mix(in srgb,var(--muted-bg) 55%, transparent); }
-.topbar nav a.nav-link--active:not(.nav-link) { color:var(--text); background:color-mix(in srgb,var(--muted-bg) 70%, transparent); }
+:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ring) 80%, transparent);
+  border-radius: .75rem;
+}
 
-/* Hero Strip */
-.hero { background:linear-gradient(140deg, color-mix(in oklab,var(--primary) 12%, transparent) 0%, color-mix(in oklab,var(--accent-cyan) 10%, transparent) 100%); @apply rounded-xl mb-6 relative; padding:1.5rem 1.75rem; display:flex; gap:1.5rem; align-items:flex-start; }
-.hero h1 { @apply text-xl font-semibold; letter-spacing:-.5px; margin:0 0 .35rem; }
-.hero p { @apply text-sm; margin:0; color:var(--text-muted); }
-.hero .toolbar { margin-left:auto; }
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
+}
 
-/* Toolbar */
-.toolbar { @apply flex flex-wrap items-center gap-2; min-height:2.25rem; }
+/* Top bar */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-border) 80%, transparent);
+  backdrop-filter: blur(18px);
+  background: color-mix(in srgb, var(--surface) 65%, transparent);
+}
+.topbar > .container-page {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1rem 1.5rem;
+}
+.brand-block {
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+.brand-logo {
+  font-weight: 700;
+  letter-spacing: -.04em;
+  font-size: 1.1rem;
+  background: var(--gradient-accent);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-decoration: none;
+}
+.brand-logo:hover { filter: brightness(1.05); }
+.brand-tag {
+  font-size: .7rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.nav {
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+  margin-left: auto;
+}
+.nav-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  font-weight: 500;
+  font-size: .8rem;
+  letter-spacing: .015em;
+  padding: .55rem .85rem;
+  border-radius: 999px;
+  text-decoration: none;
+  color: var(--text-muted);
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--surface) 55%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.1), 0 1px 2px rgba(15,23,42,0.08);
+}
+.nav-link:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--surface) 70%, transparent);
+}
+.nav-link.active,
+.nav-link--active,
+.nav-link.active:hover,
+.nav-link--active:hover {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--primary) 35%, transparent);
+  background: color-mix(in srgb, var(--surface) 85%, transparent);
+  box-shadow: 0 6px 18px -10px rgba(79,70,229,0.45);
+}
+.nav-link--icon {
+  padding-inline: .65rem;
+}
+
+/* Shell */
+.app-shell {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface) 75%, transparent) 0%, transparent 65%);
+}
+.page {
+  position: relative;
+  @apply space-y-8;
+}
+
+/* Flash */
+.flash {
+  border-radius: 1rem;
+  padding: .75rem 1rem;
+  font-weight: 500;
+  border: 1px solid var(--flash-ring);
+  box-shadow: 0 14px 35px -24px rgba(15,23,42,0.4);
+}
+.flash-ok { background: var(--success-bg); color: var(--success-fg); border-color: var(--success-brd); }
+.flash-error { background: var(--error-bg); color: var(--error-fg); border-color: var(--error-brd); }
+
+/* Page header */
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+.page-title {
+  font-size: clamp(1.35rem, 1.8vw, 1.9rem);
+  font-weight: 700;
+  letter-spacing: -.03em;
+  margin-bottom: .25rem;
+}
+.page-subtitle {
+  font-size: .95rem;
+  color: var(--text-muted);
+  max-width: 38rem;
+}
+.page-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+  align-items: center;
+}
+
+/* Hero */
+.hero {
+  background: var(--hero-gradient);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 70%, transparent);
+  border-radius: 1.5rem;
+  padding: 1.75rem 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-start;
+  box-shadow: 0 25px 65px -50px rgba(79,70,229,0.75);
+}
+.hero h1 {
+  margin: 0 0 .4rem;
+  font-size: clamp(1.25rem, 1.8vw, 1.6rem);
+  font-weight: 600;
+  letter-spacing: -.03em;
+}
+.hero p {
+  margin: 0;
+  font-size: .95rem;
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
+}
+.hero .toolbar { margin-left: auto; }
 
 /* Cards */
-.card { background:var(--surface); border:1px solid var(--surface-border); box-shadow:var(--shadow-sm); @apply rounded-2xl p-6; position:relative; }
-.card:hover { box-shadow:var(--shadow); }
-.card + .card { @apply mt-5; }
-.panel { background:var(--surface); border:1px solid var(--surface-border); box-shadow:var(--shadow-sm); @apply rounded-xl p-4; }
+.card {
+  position: relative;
+  border-radius: 1.5rem;
+  border: 1px solid color-mix(in srgb, var(--surface-border) 80%, transparent);
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+.card:hover { box-shadow: var(--shadow); }
+.card[data-tone="muted"] {
+  background: color-mix(in srgb, var(--muted-bg) 90%, transparent);
+  border-color: var(--muted-brd);
+  box-shadow: none;
+}
+.panel {
+  border-radius: 1.1rem;
+  border: 1px solid color-mix(in srgb, var(--surface-border) 80%, transparent);
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  padding: 1rem;
+}
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 1rem;
+}
+.stat-card {
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 80%, transparent);
+  border-radius: 1.1rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: .45rem;
+}
+.stat-card span.label {
+  font-size: .7rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.stat-card span.value {
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+/* Empty state */
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  border-radius: 1.5rem;
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--surface-border) 80%, transparent);
+}
+.empty-state i {
+  display: inline-flex;
+  width: 3rem;
+  height: 3rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+}
 
 /* Buttons */
-.btn { @apply inline-flex items-center gap-2 font-medium text-sm rounded-xl select-none cursor-pointer; padding:.65rem 1rem; line-height:1.1; border:1px solid transparent; background:transparent; transform:translateY(0); }
-.btn:hover { transform:translateY(1px); }
-.btn:focus-visible { box-shadow:0 0 0 2px var(--ring); }
-.btn-primary { background:var(--primary); border-color:var(--primary); color:#fff; box-shadow:0 2px 4px -1px rgba(0,0,0,.15); }
-.btn-primary:hover { background:var(--primary-hover); }
-.btn-secondary { background:var(--surface); border:1px solid var(--surface-border); color:var(--text); }
-.btn-secondary:hover { background:var(--muted-bg); }
-.btn-ghost { background:transparent; border-color:transparent; color:var(--text-muted); }
-.btn-ghost:hover { color:var(--text); background:color-mix(in srgb,var(--muted-bg) 60%, transparent); }
-.btn[disabled], .btn:disabled { @apply opacity-50 cursor-not-allowed; transform:none; }
+.btn {
+  @apply inline-flex items-center gap-2 font-medium text-sm rounded-full select-none cursor-pointer;
+  padding: .7rem 1.2rem;
+  line-height: 1.1;
+  border: 1px solid transparent;
+  background: transparent;
+  transform: translateY(0);
+}
+.btn:hover { transform: translateY(1px); }
+.btn:focus-visible { box-shadow: 0 0 0 2px var(--ring); }
+.btn-primary {
+  background: var(--gradient-accent);
+  color: #fff;
+  border: none;
+  box-shadow: 0 18px 40px -24px rgba(79,70,229,0.75);
+}
+.btn-primary:hover { filter: brightness(1.02); }
+.btn-secondary {
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 80%, transparent);
+  color: var(--text);
+}
+.btn-secondary:hover { background: color-mix(in srgb, var(--surface) 96%, transparent); }
+.btn-ghost {
+  background: transparent;
+  color: var(--text-muted);
+}
+.btn-ghost:hover { color: var(--text); background: color-mix(in srgb, var(--surface) 75%, transparent); }
+.btn[disabled], .btn:disabled { @apply opacity-50 cursor-not-allowed; transform: none; }
 
-/* Form Controls */
-.label { @apply block uppercase tracking-wide font-semibold text-[0.65rem] mb-1; color:var(--text-muted); }
-.input, .select, .textarea { background:var(--surface); border:1px solid var(--surface-border); color:var(--text); @apply w-full rounded-xl text-sm; padding:0.625rem 0.9rem; min-height:44px; line-height:1.2; }
-.input::placeholder, .textarea::placeholder { color:color-mix(in srgb,var(--text-muted) 75%, transparent); }
-.input:focus, .select:focus, .textarea:focus { border-color:var(--ring); box-shadow:0 0 0 2px var(--ring), 0 1px 0 0 rgba(0,0,0,.05); }
+/* Accent link */
+.link-accent {
+  color: var(--primary);
+  font-weight: 500;
+  text-decoration: none;
+}
+.link-accent:hover { text-decoration: underline; }
+
+/* Form controls */
+.label {
+  @apply block uppercase tracking-wide font-semibold text-[0.65rem] mb-1;
+  color: var(--text-muted);
+}
+.input, .select, .textarea {
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 85%, transparent);
+  color: var(--text);
+  @apply w-full rounded-xl text-sm;
+  padding: 0.65rem 0.95rem;
+  min-height: 44px;
+  line-height: 1.3;
+}
+.input::placeholder, .textarea::placeholder { color: color-mix(in srgb, var(--text-muted) 70%, transparent); }
+.input:focus, .select:focus, .textarea:focus {
+  border-color: color-mix(in srgb, var(--ring) 85%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ring) 45%, transparent);
+}
 
 /* Badges */
-.badge { @apply inline-flex items-center font-medium; font-size:10.5px; line-height:1; padding:.25rem .55rem; border-radius:999px; border:1px solid var(--muted-brd); background:var(--muted-bg); color:var(--muted-fg); letter-spacing:.25px; }
-.badge-success { background:var(--success-bg); color:var(--success-fg); border-color:var(--success-brd); }
-.badge-error { background:var(--error-bg); color:var(--error-fg); border-color:var(--error-brd); }
-.badge-muted { background:var(--muted-bg); color:var(--muted-fg); border-color:var(--muted-brd); }
+.badge {
+  @apply inline-flex items-center font-medium;
+  font-size: 10.5px;
+  line-height: 1;
+  padding: .35rem .65rem;
+  border-radius: 999px;
+  border: 1px solid var(--muted-brd);
+  background: color-mix(in srgb, var(--muted-bg) 90%, transparent);
+  color: var(--muted-fg);
+  letter-spacing: .25px;
+}
+.badge-success { background: var(--success-bg); color: var(--success-fg); border-color: var(--success-brd); }
+.badge-error { background: var(--error-bg); color: var(--error-fg); border-color: var(--error-brd); }
+.badge-muted { background: color-mix(in srgb, var(--muted-bg) 92%, transparent); color: var(--muted-fg); }
 
-/* Table */
-.table { @apply w-full text-sm; border-collapse:separate; border-spacing:0; }
-.table thead th { position:sticky; top:0; z-index:5; backdrop-filter:blur(6px); background:var(--muted-bg); color:var(--text-muted); @apply font-medium text-left; padding:.6rem .9rem; }
-.table tbody td { padding:.55rem .9rem; vertical-align:top; }
-.table tbody tr { border-top:1px solid var(--surface-border); }
-.table tbody tr:nth-child(even) { background:color-mix(in srgb,var(--muted-bg) 35%, transparent); }
-.table tbody tr:hover { background:color-mix(in srgb,var(--muted-bg) 55%, transparent); }
-.table tbody tr:last-child { border-bottom:1px solid var(--surface-border); }
+/* Tables */
+.table-wrap {
+  border-radius: 1.35rem;
+  border: 1px solid color-mix(in srgb, var(--surface-border) 85%, transparent);
+  overflow: hidden;
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+}
+.table {
+  @apply w-full text-sm;
+  border-collapse: separate;
+  border-spacing: 0;
+  min-width: 100%;
+}
+.table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: color-mix(in srgb, var(--table-header-bg) 100%, var(--surface));
+  color: var(--text-muted);
+  @apply font-medium text-left;
+  padding: .7rem 1rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-border) 75%, transparent);
+  backdrop-filter: blur(16px);
+}
+.table tbody td {
+  padding: .65rem 1rem;
+  vertical-align: middle;
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-border) 75%, transparent);
+}
+.table tbody tr:nth-child(even) { background: color-mix(in srgb, var(--table-row-alt) 100%, transparent); }
+.table tbody tr:hover { background: color-mix(in srgb, var(--table-row-hover) 100%, transparent); }
+.table tbody tr:last-child td { border-bottom: none; }
 
-/* Flash Messages */
-.flash-ok, .flash-error { @apply rounded-xl text-sm font-medium; padding:.65rem 1rem; border:1px solid; }
-.flash-ok { background:var(--success-bg); color:var(--success-fg); border-color:var(--success-brd); }
-.flash-error { background:var(--error-bg); color:var(--error-fg); border-color:var(--error-brd); }
-
-/* Icons */
-.icon { @apply inline-flex items-center justify-center leading-none; font-size:0.875rem; }
-.icon-sm { font-size:0.75rem; }
-.icon-xs { font-size:0.625rem; }
-.icon-muted { color:var(--text-muted); }
-.icon-primary { color:var(--primary); }
+/* Flash callouts */
+.callout {
+  border-radius: 1.25rem;
+  border: 1px solid var(--muted-brd);
+  background: color-mix(in srgb, var(--muted-bg) 92%, transparent);
+  color: var(--muted-fg);
+  @apply px-5 py-4 text-sm flex gap-3 items-start;
+}
+.callout .icon {
+  font-size: .8rem;
+  color: var(--primary);
+  margin-top: .2rem;
+}
 
 /* Tooltip */
 .tooltip { @apply relative inline-flex items-center; }
-.tooltip .tip { @apply hidden absolute z-50 text-[11px] leading-snug rounded-lg px-3 py-2; width:15rem; left:50%; top:calc(100% + .5rem); transform:translateX(-50%); background:var(--surface); color:var(--text); border:1px solid var(--surface-border); box-shadow:0 6px 18px -6px rgba(0,0,0,.18); }
+.tooltip .tip {
+  @apply hidden absolute z-50 text-[11px] leading-snug rounded-lg px-3 py-2;
+  width: 15rem;
+  left: 50%;
+  top: calc(100% + .5rem);
+  transform: translateX(-50%);
+  background: color-mix(in srgb, var(--surface) 95%, transparent);
+  color: var(--text);
+  border: 1px solid color-mix(in srgb, var(--surface-border) 85%, transparent);
+  box-shadow: 0 22px 45px -35px rgba(15,23,42,0.6);
+}
 .tooltip:hover .tip, .tooltip:focus-within .tip { @apply block; }
 
-/* Callout */
-.callout { background:linear-gradient(135deg, color-mix(in oklab,var(--muted-bg) 95%, transparent) 0%, color-mix(in oklab,var(--muted-bg) 75%, transparent) 100%); border:1px solid var(--muted-brd); color:var(--muted-fg); @apply rounded-xl px-4 py-3 text-sm flex gap-3 items-start; }
-.callout .icon { font-size:.7rem; color:var(--primary); margin-top:2px; }
+/* Icons */
+.icon { @apply inline-flex items-center justify-center leading-none; font-size: .9rem; }
+.icon-sm { font-size: .75rem; }
+.icon-xs { font-size: .6rem; }
+.icon-muted { color: var(--text-muted); }
+.icon-primary { color: var(--primary); }
 
-/* Panel (compact variant already defined above as .panel) */
-
-/* Skeleton Loader */
-@keyframes skeleton-shimmer { 0% { background-position:-200% 0; } 100% { background-position:200% 0; } }
-.skeleton { position:relative; overflow:hidden; border-radius:.5rem; background:linear-gradient(110deg, color-mix(in srgb,var(--muted-bg) 96%, transparent) 25%, color-mix(in srgb,var(--muted-bg) 86%, transparent) 37%, color-mix(in srgb,var(--muted-bg) 96%, transparent) 63%); background-size:200% 100%; animation:skeleton-shimmer 1.3s linear infinite; }
-
-/* Utilities */
-.muted { color:var(--text-muted); }
-
-/* Responsive */
-@media (max-width:640px) { .card { @apply p-5; } .hero { padding:1.25rem 1.25rem; flex-direction:column; } .container-page { @apply px-3; } .toolbar { @apply gap-1; } }
-
-/* Scrollable table wrapper with sticky header */
-.table-wrap { max-height: 70vh; overflow: auto; border-radius: 0.75rem; }
-.table thead th {
-    position: sticky; top: 0; z-index: 10;
-    background: var(--surface);
-    box-shadow: 0 1px 0 var(--surface-border);
+/* Footer */
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--text-muted);
 }
+
+/* Responsive tweaks */
+@media (max-width: 768px) {
+  .topbar > .container-page { padding: .8rem 1rem; }
+  .nav { gap: .2rem; }
+  .nav-link { font-size: .75rem; padding: .5rem .75rem; }
+  .page { @apply space-y-6; }
+  .card { border-radius: 1.25rem; padding: 1.25rem; }
+  .table thead th { font-size: .72rem; }
+}
+
+@media (max-width: 640px) {
+  .brand-block { flex: 1; }
+  .brand-tag { display: none; }
+  .page-header { flex-direction: column; align-items: flex-start; }
+  .page-actions { width: 100%; justify-content: flex-start; }
+  .table-wrap { border-radius: 1rem; }
+}
+

--- a/app/views/exports/index.html.erb
+++ b/app/views/exports/index.html.erb
@@ -1,19 +1,33 @@
 <!-- app/views/exports/index.html.erb -->
-<h1 class="text-lg font-semibold mb-4">Exports</h1>
-<div class="flex items-center justify-between mb-5">
-  <p class="text-sm text-slate-600 max-w-prose">Recent export jobs. Generated exports provide a download link. Queue a <%= link_to "new export", new_export_path, class: "text-[color:var(--primary)] hover:underline" %>.</p>
-  <%= link_to "New Export", new_export_path, class: "btn btn-primary" %>
+<div class="page-header">
+  <div>
+    <h1 class="page-title">Exports</h1>
+    <p class="page-subtitle">Queue QuickBooks or Xero-ready CSVs, track their generation, and download once complete.</p>
+  </div>
+  <div class="page-actions">
+    <%= link_to "New export", new_export_path, class: "btn btn-primary" %>
+  </div>
+</div>
+
+<div class="hero" data-tone="muted">
+  <div class="space-y-2">
+    <h2 class="text-base font-semibold">Build the journal you need</h2>
+    <p>Exports aggregate parsed statement and accounting data for the selected period. Configure your mapping profile once, then re-run whenever you close a reconciliation window.</p>
+  </div>
+  <div class="toolbar">
+    <%= link_to "Adjust mapping", edit_mapping_profile_path, class: "btn btn-secondary" %>
+  </div>
 </div>
 
 <% if @exports.blank? %>
-  <div class="card text-center">
-    <i class="fa-regular fa-file-export icon icon-muted text-xl"></i>
-    <h2 class="mt-2 font-medium">No exports yet</h2>
-    <p class="text-sm text-slate-600 mt-1">Create your first export to download summarized data.</p>
-    <div class="mt-4"><%= link_to "New Export", new_export_path, class: "btn btn-primary" %></div>
+  <div class="empty-state">
+    <i class="fa-regular fa-file-export"></i>
+    <h2 class="mt-4 text-lg font-semibold">No exports yet</h2>
+    <p class="text-sm text-[color:var(--text-muted)] mt-2">Queue your first export to generate a reconciliation-ready CSV.</p>
+    <div class="mt-5"><%= link_to "New export", new_export_path, class: "btn btn-primary" %></div>
   </div>
 <% else %>
-  <div class="card overflow-hidden p-0">
+  <div class="table-wrap">
     <table class="table">
       <thead>
         <tr>
@@ -33,10 +47,10 @@
           <td><%= ex.period_start %> – <%= ex.period_end %></td>
           <td><%= status_badge(ex.status) %></td>
           <td><%= ex.generated? && ex.bytes ? number_to_human_size(ex.bytes) : "—" %></td>
-          <td class="text-right space-x-2">
-            <%= link_to "View", export_path(ex), class: "text-[color:var(--primary)] hover:underline" %>
+          <td class="text-right space-x-3">
+            <%= link_to "View", export_path(ex), class: "link-accent" %>
             <% if ex.generated? && ex.file_path.present? && File.exist?(ex.file_path) %>
-              <%= link_to "Download", download_export_path(ex), class: "text-[color:var(--primary)] hover:underline" %>
+              <%= link_to "Download", download_export_path(ex), class: "link-accent" %>
             <% end %>
           </td>
         </tr>
@@ -47,8 +61,8 @@
 <% end %>
 
 <div class="mt-8 card">
-  <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">Status legend</div>
-  <ul class="text-xs space-y-1">
+  <div class="text-xs uppercase tracking-wide text-[color:var(--text-muted)] mb-2">Status legend</div>
+  <ul class="text-xs space-y-1 text-[color:var(--text-muted)]">
     <li><span class="badge badge-success">Generated</span> Export finished successfully and is ready to download.</li>
     <li><span class="badge badge-error">Failed</span> Export generation encountered an error (see export page).</li>
     <li><span class="badge badge-muted">Queued</span> Waiting for background job processing.</li>

--- a/app/views/exports/new.html.erb
+++ b/app/views/exports/new.html.erb
@@ -1,6 +1,13 @@
 <!-- app/views/exports/new.html.erb -->
-<h1 class="text-lg font-semibold mb-2">New export</h1>
-<p class="text-sm text-slate-600 mb-6">Create a QuickBooks or Xero CSV for a date range.</p>
+<div class="page-header">
+  <div>
+    <h1 class="page-title">New export</h1>
+    <p class="page-subtitle">Assemble a QuickBooks or Xero CSV for your reconciliation window using parsed Adyen data.</p>
+  </div>
+  <div class="page-actions">
+    <%= link_to "Back to exports", exports_path, class: "btn btn-ghost" %>
+  </div>
+</div>
 
 <%= form_with model: @export, url: exports_path, class: "space-y-6" do |f| %>
   <div class="card">
@@ -27,12 +34,10 @@
         <%= f.collection_select :mapping_profile_id, MappingProfile.all, :id, :name, {}, class: "select mt-1" %>
       </div>
 
-      <div class="md:col-span-2 rounded-xl border border-[color:var(--muted-brd)] bg-[color:var(--muted-bg)] px-4 py-3">
-        <div class="flex items-start gap-2">
-          <i class="fa-solid fa-circle-info icon icon-primary mt-1"></i>
-          <p class="text-sm text-slate-700">
-            Exports use amounts aggregated in <b>DailySummary</b> (minor units). Make sure your Statement/Accounting CSVs are parsed for the selected period.
-          </p>
+      <div class="md:col-span-2 callout">
+        <i class="fa-solid fa-circle-info icon icon-primary"></i>
+        <div>
+          <p class="text-sm">Exports use amounts aggregated in <strong>DailySummary</strong> (minor units). Make sure your statement and accounting CSVs are parsed for the selected period.</p>
         </div>
       </div>
 
@@ -48,7 +53,7 @@
   </div>
 
   <div class="flex items-center justify-end gap-3">
-    <%= link_to "Cancel", report_files_path, class: "btn btn-secondary" %>
+    <%= link_to "Cancel", exports_path, class: "btn btn-secondary" %>
     <%= f.submit "Queue export", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/exports/show.html.erb
+++ b/app/views/exports/show.html.erb
@@ -1,11 +1,18 @@
 <div data-controller="export-poll" data-export-poll-status-value="<%= @export.status %>" data-export-poll-export-id-value="<%= @export.id %>">
-  <h1 class="text-lg font-semibold mb-2">Export</h1>
-  <p class="text-sm text-slate-600 mb-6">
-    <strong>Kind:</strong> <%= @export.kind.humanize %> ·
-    <strong>Status:</strong> <%= status_badge(@export.status) %> ·
-    <strong>Period:</strong> <%= @export.period_start %> – <%= @export.period_end %>
-    <% if @row_count %> · <strong>Rows:</strong> <%= @row_count %><% end %>
-  </p>
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Export</h1>
+      <p class="page-subtitle">
+        <strong>Kind:</strong> <%= @export.kind.humanize %> ·
+        <strong>Status:</strong> <%= status_badge(@export.status) %> ·
+        <strong>Period:</strong> <%= @export.period_start %> – <%= @export.period_end %>
+        <% if @row_count %> · <strong>Rows:</strong> <%= @row_count %><% end %>
+      </p>
+    </div>
+    <div class="page-actions">
+      <%= link_to "All exports", exports_path, class: "btn btn-ghost" %>
+    </div>
+  </div>
 
   <% if @export.generated? %>
     <div class="card space-y-4">
@@ -13,15 +20,15 @@
         <div class="font-medium">Export generated</div>
         <%= link_to "Download CSV", download_export_path(@export), class: "btn btn-primary" %>
       </div>
-      <p class="text-sm text-slate-600">The CSV file is ready. Stored on server path below.</p>
-      <pre class="text-xs bg-white border border-[color:var(--surface-border)] rounded-xl p-3 overflow-x-auto"><%= @export.file_path %></pre>
+      <p class="text-sm text-[color:var(--text-muted)]">The CSV file is ready. Stored on the server path below.</p>
+      <pre class="text-xs bg-[color:var(--surface-elevated)] border border-[color:var(--surface-border)] rounded-xl p-4 overflow-x-auto"><%= @export.file_path %></pre>
     </div>
   <% elsif @export.failed? %>
-    <div class="card" style="background: var(--error-bg); border-color: var(--error-brd); color: var(--error-fg);">
-      <div class="font-medium mb-2">Generation failed</div>
-      <pre class="text-xs bg-white/70 border border-[color:var(--error-brd)] rounded-xl p-3 overflow-x-auto"><%= @export.error %></pre>
-      <div>
-        <%= link_to "Retry", new_export_path, class: "btn btn-secondary mt-2" %>
+    <div class="card" data-tone="muted">
+      <div class="font-medium mb-2 text-[color:var(--error-fg)]">Generation failed</div>
+      <pre class="text-xs bg-white/80 border border-[color:var(--error-brd)] rounded-xl p-4 overflow-x-auto text-[color:var(--error-fg)]"><%= @export.error %></pre>
+      <div class="mt-3">
+        <%= link_to "Queue new export", new_export_path, class: "btn btn-secondary" %>
       </div>
     </div>
   <% else %>
@@ -29,7 +36,7 @@
       <div class="flex items-start justify-between">
         <div>
           <div class="font-medium mb-1">Export queued or processing…</div>
-          <p class="text-sm text-slate-600">Refresh this page in a moment; it will update once generated.</p>
+          <p class="text-sm text-[color:var(--text-muted)]">This page refreshes automatically. It will update once the CSV has been generated.</p>
         </div>
         <%= link_to "Refresh", export_path(@export), class: "btn btn-ghost" %>
       </div>
@@ -43,9 +50,9 @@
     </div>
   <% end %>
 
-  <div class="mt-6 flex gap-3">
-    <%= link_to "All Exports", exports_path, class: "btn btn-secondary" %>
-    <%= link_to "New Export", new_export_path, class: "btn btn-ghost" %>
+  <div class="mt-6 flex gap-3 flex-wrap">
+    <%= link_to "All exports", exports_path, class: "btn btn-secondary" %>
+    <%= link_to "New export", new_export_path, class: "btn btn-primary" %>
     <%= link_to "Uploads", report_files_path, class: "btn btn-ghost" %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,45 +25,49 @@
   </head>
 
   <body class="min-h-screen" data-controller="theme">
-  <header class="topbar">
-    <div class="container-page h-14 flex items-center justify-between">
-      <a href="/" class="brand-logo text-base font-semibold tracking-tight bg-gradient-to-r from-violet-500 via-fuchsia-500 to-pink-500 bg-clip-text text-transparent">
-        Adyen Recon
-      </a>
-      <nav class="nav items-center gap-1">
-        <%= link_to "Uploads", report_files_path, class: ["nav-link", ("active" if current_page?(report_files_path))] %>
-        <%= link_to "Exports", exports_path, class: ["nav-link", ("active" if current_page?(exports_path))] %>
-        <%= link_to "New Export", new_export_path, class: ["nav-link", ("active" if current_page?(new_export_path))] %>
-        <%= link_to "Mapping", edit_mapping_profile_path, class: ["nav-link", ("active" if current_page?(edit_mapping_profile_path))] %>
-        <%= link_to "Reconciliation", reconciliations_path, class: "px-3 py-2 rounded-xl hover:bg-slate-100 nav-link" %>
-        <button type="button" class="nav-link" data-action="theme#toggle" aria-label="Toggle theme">
-          <i class="fa fa-moon icon-sm" data-theme-target="icon"></i>
-        </button>
-      </nav>
-    </div>
-  </header>
+    <div class="min-h-screen flex flex-col app-surface">
+      <header class="topbar">
+        <div class="container-page">
+          <div class="brand-block">
+            <a href="/" class="brand-logo">Adyen Recon</a>
+            <span class="brand-tag">Reconciliation workspace</span>
+          </div>
+          <nav class="nav" aria-label="Primary">
+            <%= link_to "Uploads", report_files_path, class: ["nav-link", ("active" if current_page?(report_files_path))] %>
+            <%= link_to "Exports", exports_path, class: ["nav-link", ("active" if current_page?(exports_path))] %>
+            <%= link_to "New export", new_export_path, class: ["nav-link", ("active" if current_page?(new_export_path))] %>
+            <%= link_to "Mapping", edit_mapping_profile_path, class: ["nav-link", ("active" if current_page?(edit_mapping_profile_path))] %>
+            <%= link_to "Reconciliation", reconciliations_path, class: ["nav-link", ("active" if current_page?(reconciliations_path))] %>
+            <button type="button" class="nav-link nav-link--icon" data-action="theme#toggle" aria-label="Toggle theme">
+              <i class="fa fa-moon icon-sm" data-theme-target="icon"></i>
+            </button>
+          </nav>
+        </div>
+      </header>
 
-  <div class="app-shell">
-    <div class="container-page px-4 pt-4 space-y-2">
-      <% if notice.present? %>
-        <div class="flash-ok"><%= notice %></div>
-      <% end %>
-      <% if alert.present? %>
-        <div class="flash-error"><%= alert %></div>
-      <% end %>
-    </div>
+      <div class="app-shell flex-1">
+        <div class="container-page pt-6 px-4 space-y-3">
+          <% if notice.present? %>
+            <div class="flash flash-ok"><%= notice %></div>
+          <% end %>
+          <% if alert.present? %>
+            <div class="flash flash-error"><%= alert %></div>
+          <% end %>
+        </div>
 
-    <main class="container-page px-4 py-6">
-      <%= yield %>
-    </main>
-
-    <footer class="site-footer">
-      <div class="container-page px-4 py-6 text-xs text-slate-500 flex items-center justify-between">
-        <span>© <%= Time.current.year %> Adyen Recon</span>
-        <span class="muted">Reconciliation Suite</span>
+        <main class="page container-page px-4 py-8">
+          <%= yield %>
+        </main>
       </div>
-    </footer>
-  </div>
 
+      <footer class="site-footer">
+        <div class="container-page px-4 py-6 text-xs">
+          <div class="footer-inner">
+            <span>© <%= Time.current.year %> Adyen Recon</span>
+            <span class="muted">Focused on matching the numbers.</span>
+          </div>
+        </div>
+      </footer>
+    </div>
   </body>
 </html>

--- a/app/views/mapping_profiles/edit.html.erb
+++ b/app/views/mapping_profiles/edit.html.erb
@@ -1,6 +1,13 @@
 <!-- app/views/mapping_profiles/edit.html.erb -->
-<h1 class="text-lg font-semibold mb-2">Mapping profile</h1>
-<p class="text-sm text-slate-600 mb-6">Set your GL (General Ledger) account codes used for exports.</p>
+<div class="page-header">
+  <div>
+    <h1 class="page-title">Mapping profile</h1>
+    <p class="page-subtitle">Define the GL codes that power your export journals. These defaults are applied whenever you queue a new file.</p>
+  </div>
+  <div class="page-actions">
+    <%= link_to "Back", exports_path, class: "btn btn-ghost" %>
+  </div>
+</div>
 
 <%= form_with model: @profile, url: mapping_profile_path, method: :put, class: "space-y-6" do |f| %>
   <div class="card">
@@ -43,7 +50,7 @@
   </div>
 
   <div class="flex items-center justify-end gap-3">
-    <%= link_to "Cancel", report_files_path, class: "btn btn-secondary" %>
+    <%= link_to "Cancel", exports_path, class: "btn btn-secondary" %>
     <%= f.submit "Save", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/reconciliations/index.html.erb
+++ b/app/views/reconciliations/index.html.erb
@@ -1,8 +1,29 @@
 <!-- app/views/reconciliations/index.html.erb -->
 
+<div class="page-header">
+  <div>
+    <h1 class="page-title">Reconciliation</h1>
+    <p class="page-subtitle">Track how statement, accounting, and computed totals align for each day — and surface any variance quickly.</p>
+  </div>
+  <div class="page-actions">
+    <%= link_to "Uploads", report_files_path, class: "btn btn-ghost" %>
+  </div>
+</div>
+
+<div class="hero" data-tone="muted">
+  <div class="space-y-2">
+    <h2 class="text-base font-semibold">Filter and rebuild confidently</h2>
+    <p>Focus on the scope and currency that matter today. Once fresh files are parsed, rebuild the selected range to refresh the computed totals.</p>
+  </div>
+  <div class="toolbar text-sm text-[color:var(--text-muted)]">
+    <span class="badge badge-muted">Scope aware</span>
+    <span class="badge badge-muted">Variance highlights</span>
+  </div>
+</div>
+
 <!-- FILTER (GET) -->
-<div class="mb-4 card">
-  <div class="grid grid-cols-1 md:grid-cols-6 gap-3 p-4">
+<div class="mb-6 card">
+  <div class="grid grid-cols-1 md:grid-cols-6 gap-4">
     <%= form_with url: reconciliations_path, method: :get, local: true, class: "contents" do %>
       <div>
         <label class="label">Scope</label>
@@ -48,9 +69,8 @@
 
 
 <!-- TABLE -->
-<div class="card p-0">
-  <div class="table-wrap">
-    <table class="table">
+<div class="table-wrap">
+  <table class="table">
       <thead>
       <tr>
         <th>Date</th>
@@ -78,11 +98,10 @@
           <td class="text-right">
             <%= link_to "Details",
                         by_key_reconciliations_path(date: day.date, currency: day.currency, scope: day.account_scope),
-                        class: "text-[color:var(--primary)] hover:underline" %>
+                        class: "link-accent" %>
           </td>
         </tr>
       <% end %>
       </tbody>
-    </table>
-  </div>
+  </table>
 </div>

--- a/app/views/reconciliations/show.html.erb
+++ b/app/views/reconciliations/show.html.erb
@@ -1,20 +1,32 @@
-<h1 class="text-lg font-semibold mb-2">Recon for <%= @day.date %></h1>
-<p class="text-sm text-slate-600 mb-4"><%= @day.account_scope %> • <%= @day.currency %></p>
+<div class="page-header">
+  <div>
+    <h1 class="page-title">Recon for <%= @day.date %></h1>
+    <p class="page-subtitle"><%= @day.account_scope || "(nil)" %> • <%= @day.currency %></p>
+  </div>
+  <div class="page-actions">
+    <% if @prev_date %>
+      <%= link_to "← #{@prev_date}", by_key_reconciliations_path(date: @prev_date, currency: @day.currency, scope: @day.account_scope), class: "btn btn-ghost" %>
+    <% end %>
+    <% if @next_date %>
+      <%= link_to "#{@next_date} →", by_key_reconciliations_path(date: @next_date, currency: @day.currency, scope: @day.account_scope), class: "btn btn-ghost" %>
+    <% end %>
+  </div>
+</div>
 
 
-<div class="mb-4 flex items-center justify-between">
-  <div class="flex items-center gap-2">
+<div class="card mb-6 flex flex-wrap items-center justify-between gap-3">
+  <div class="flex items-center gap-3">
     <%= link_to "← Back to list",
                 reconciliations_path(scope: params[:scope], currency: params[:currency], from: params[:from], to: params[:to]),
                 class: "btn btn-secondary" %>
-    <span class="help">Scope: <%= @day.account_scope || "(nil)" %> • <%= @day.currency %></span>
+    <span class="text-sm text-[color:var(--text-muted)]">Scope: <%= @day.account_scope || "(nil)" %> • <%= @day.currency %></span>
   </div>
   <div class="flex items-center gap-2">
     <% if @prev_date %>
-      <%= link_to "← #{@prev_date}", by_key_reconciliations_path(date: @prev_date, currency: @day.currency, scope: @day.account_scope), class: "btn btn-secondary" %>
+      <%= link_to "← #{@prev_date}", by_key_reconciliations_path(date: @prev_date, currency: @day.currency, scope: @day.account_scope), class: "btn btn-ghost" %>
     <% end %>
     <% if @next_date %>
-      <%= link_to "#{@next_date} →", by_key_reconciliations_path(date: @next_date, currency: @day.currency, scope: @day.account_scope), class: "btn btn-secondary" %>
+      <%= link_to "#{@next_date} →", by_key_reconciliations_path(date: @next_date, currency: @day.currency, scope: @day.account_scope), class: "btn btn-ghost" %>
     <% end %>
   </div>
 </div>
@@ -23,36 +35,30 @@
 
 
 
-<div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-  <div class="card">
-    <div class="text-xs uppercase text-slate-500">Statement total</div>
-    <div class="mt-1 text-lg font-semibold">
-      <%= number_to_currency(@day.statement_total_cents.to_i / 100.0, unit: @day.currency) %>
-    </div>
+<div class="stat-grid">
+  <div class="stat-card">
+    <span class="label">Statement total</span>
+    <span class="value"><%= number_to_currency(@day.statement_total_cents.to_i / 100.0, unit: @day.currency) %></span>
   </div>
-  <div class="card">
-    <div class="text-xs uppercase text-slate-500">Accounting total</div>
-    <div class="mt-1 text-lg font-semibold">
-      <%= number_to_currency(@day.accounting_total_cents.to_i / 100.0, unit: @day.currency) %>
-    </div>
+  <div class="stat-card">
+    <span class="label">Accounting total</span>
+    <span class="value"><%= number_to_currency(@day.accounting_total_cents.to_i / 100.0, unit: @day.currency) %></span>
   </div>
-  <div class="card">
-    <div class="text-xs uppercase text-slate-500">Computed total</div>
-    <div class="mt-1 text-lg font-semibold">
-      <%= number_to_currency(@day.computed_total_cents.to_i / 100.0, unit: @day.currency) %>
-    </div>
+  <div class="stat-card">
+    <span class="label">Computed total</span>
+    <span class="value"><%= number_to_currency(@day.computed_total_cents.to_i / 100.0, unit: @day.currency) %></span>
   </div>
 </div>
 
 <div class="card mb-6">
   <h2 class="text-sm font-semibold mb-3">Variance breakdown</h2>
   <% if @vars.blank? %>
-    <p class="text-sm text-slate-600">No variance lines recorded.</p>
+    <p class="text-sm text-[color:var(--text-muted)]">No variance lines recorded.</p>
   <% else %>
     <ul class="text-sm space-y-2">
       <% @vars.each do |v| %>
         <li class="flex items-start justify-between">
-          <span class="text-slate-700 capitalize"><%= v.kind.humanize %></span>
+          <span class="capitalize text-[color:var(--text)]"><%= v.kind.humanize %></span>
           <span><%= number_to_currency(v.amount_cents.to_i / 100.0, unit: @day.currency) %></span>
         </li>
       <% end %>
@@ -63,12 +69,12 @@
 <div class="card mb-6">
   <h2 class="text-sm font-semibold mb-3">Fee intelligence</h2>
   <% if @fees.nil? %>
-    <p class="text-sm text-slate-600">No fee data.</p>
+    <p class="text-sm text-[color:var(--text-muted)]">No fee data.</p>
   <% else %>
     <div class="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
       <% %i[scheme_fees_cents processing_fees_cents interchange_cents chargeback_fees_cents payout_fees_cents other_fees_cents].each do |k| %>
         <div class="panel">
-          <div class="text-xs uppercase text-slate-500"><%= k.to_s.sub("_cents","").humanize %></div>
+          <div class="text-xs uppercase text-[color:var(--text-muted)]"><%= k.to_s.sub("_cents","").humanize %></div>
           <div class="mt-1 font-medium"><%= number_to_currency(@fees[k].to_i / 100.0, unit: @day.currency) %></div>
         </div>
       <% end %>
@@ -79,20 +85,22 @@
 <div class="card">
   <h2 class="text-sm font-semibold mb-3">Payout matching</h2>
   <% if @payouts.blank? %>
-    <p class="text-sm text-slate-600">No payouts for this day.</p>
+    <p class="text-sm text-[color:var(--text-muted)]">No payouts for this day.</p>
   <% else %>
-    <table class="table">
-      <thead><tr><th>Adyen payout</th><th>Bank ref</th><th>Amount</th><th>Status</th></tr></thead>
-      <tbody>
-      <% @payouts.each do |p| %>
-        <tr>
-          <td class="font-mono text-xs"><%= p.adyen_payout_id %></td>
-          <td class="font-mono text-xs"><%= p.bank_ref || "—" %></td>
-          <td><%= number_to_currency(p.adyen_amount_cents.to_i / 100.0, unit: p.currency) %></td>
-          <td><span class="badge <%= { matched:"badge-success", partial:"badge-muted", conflict:"badge-error", unmatched:"badge-muted" }[p.status] %>"><%= p.status %></span></td>
-        </tr>
-      <% end %>
-      </tbody>
-    </table>
+    <div class="table-wrap">
+      <table class="table">
+        <thead><tr><th>Adyen payout</th><th>Bank ref</th><th>Amount</th><th>Status</th></tr></thead>
+        <tbody>
+        <% @payouts.each do |p| %>
+          <tr>
+            <td class="font-mono text-xs"><%= p.adyen_payout_id %></td>
+            <td class="font-mono text-xs"><%= p.bank_ref || "—" %></td>
+            <td><%= number_to_currency(p.adyen_amount_cents.to_i / 100.0, unit: p.currency) %></td>
+            <td><span class="badge <%= { matched:"badge-success", partial:"badge-muted", conflict:"badge-error", unmatched:"badge-muted" }[p.status] %>"><%= p.status %></span></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
   <% end %>
 </div>

--- a/app/views/report_files/create.html.erb
+++ b/app/views/report_files/create.html.erb
@@ -1,4 +1,12 @@
-<div>
-  <h1 class="font-bold text-4xl">ReportFiles#create</h1>
-  <p>Find me in app/views/report_files/create.html.erb</p>
+<div class="space-y-6">
+  <div class="page-header">
+    <div>
+      <h1 class="page-title">Upload queued</h1>
+      <p class="page-subtitle">We have received your file and will begin parsing it right away.</p>
+    </div>
+  </div>
+
+  <div class="card">
+    <p class="text-sm text-[color:var(--text-muted)]">Return to <%= link_to "report uploads", report_files_path, class: "link-accent" %> to monitor the progress, or drop another CSV.</p>
+  </div>
 </div>

--- a/app/views/report_files/index.html.erb
+++ b/app/views/report_files/index.html.erb
@@ -1,40 +1,61 @@
 <!-- app/views/report_files/index.html.erb -->
-<div class="flex items-center justify-between mb-5">
+<div class="page-header">
   <div>
-    <h1 class="text-lg font-semibold">Report uploads</h1>
-    <p class="text-sm text-slate-600">Upload <em><a href="https://docs.adyen.com/reporting/standard-reports/balance-platform-statement-report" target="_blank" rel="noopener" class="underline decoration-dotted hover:decoration-solid">statement</a></em> or <em><a href="https://docs.adyen.com/reporting/standard-reports/accounting-report" target="_blank" rel="noopener" class="underline decoration-dotted hover:decoration-solid">accounting</a></em> CSVs. We’ll parse and summarize them.</p>
+    <h1 class="page-title">Report uploads</h1>
+    <p class="page-subtitle">Drop Adyen <em>statement</em> or <em>accounting</em> CSVs and we will classify, parse, and prepare them for reconciliation in seconds.</p>
   </div>
-  <%= link_to "Upload report", new_report_file_path, class: "btn btn-primary" %>
+  <div class="page-actions">
+    <%= link_to "Upload report", new_report_file_path, class: "btn btn-primary" %>
+  </div>
+</div>
+
+<div class="hero" data-tone="muted">
+  <div class="space-y-2">
+    <h2 class="text-base font-semibold">Stay on top of payouts and ledger movements</h2>
+    <p>Upload the latest CSVs to enrich your reconciliation timeline. We auto-detect the file kind, keep track of currencies, and highlight any parse issues.</p>
+    <ul class="text-sm text-[color:var(--text-muted)] list-disc list-inside space-y-1">
+      <li><a href="https://docs.adyen.com/reporting/standard-reports/balance-platform-statement-report" target="_blank" rel="noopener" class="link-accent">Statement report</a> for cash movements.</li>
+      <li><a href="https://docs.adyen.com/reporting/standard-reports/accounting-report" target="_blank" rel="noopener" class="link-accent">Accounting report</a> for fee-level detail.</li>
+    </ul>
+  </div>
+  <div class="toolbar">
+    <%= link_to "Upload another file", new_report_file_path, class: "btn btn-secondary" %>
+  </div>
 </div>
 
 <% if @files.blank? %>
-  <div class="card text-center">
-    <i class="fa-regular fa-file icon icon-muted text-xl"></i>
-    <h2 class="mt-2 font-medium">No uploads yet</h2>
-    <p class="text-sm text-slate-600 mt-1">Upload your first CSV to get started.</p>
-    <div class="mt-4"><%= link_to "Upload report", new_report_file_path, class: "btn btn-primary" %></div>
+  <div class="empty-state">
+    <i class="fa-regular fa-file"></i>
+    <h2 class="mt-4 text-lg font-semibold">No uploads yet</h2>
+    <p class="text-sm text-[color:var(--text-muted)] mt-2">Bring in your first CSV to start building the reconciliation workspace.</p>
+    <div class="mt-5"><%= link_to "Upload report", new_report_file_path, class: "btn btn-primary" %></div>
   </div>
 <% else %>
-  <div class="card overflow-hidden p-0">
+  <div class="table-wrap">
     <table class="table">
       <thead>
-      <tr>
-        <th>When</th><th>Kind</th><th>Reported on</th><th>Currency</th><th>Status</th><th></th>
-      </tr>
+        <tr>
+          <th>Uploaded</th>
+          <th>Kind</th>
+          <th>Reported on</th>
+          <th>Currency</th>
+          <th>Status</th>
+          <th></th>
+        </tr>
       </thead>
       <tbody>
-      <% @files.each do |f| %>
-        <tr>
-          <td><%= l f.created_at, format: :short %></td>
-          <td class="capitalize"><%= f.kind %></td>
-          <td><%= f.reported_on %></td>
-          <td><%= f.currency %></td>
-          <td><%= status_badge(f.status) %></td>
-          <td class="text-right">
-            <%= link_to "Details", report_file_path(f), class: "text-[color:var(--primary)] hover:underline" %>
-          </td>
-        </tr>
-      <% end %>
+        <% @files.each do |f| %>
+          <tr>
+            <td><%= l f.created_at, format: :short %></td>
+            <td class="capitalize"><%= f.kind %></td>
+            <td><%= f.reported_on %></td>
+            <td><%= f.currency %></td>
+            <td><%= status_badge(f.status) %></td>
+            <td class="text-right">
+              <%= link_to "Details", report_file_path(f), class: "link-accent" %>
+            </td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   </div>

--- a/app/views/report_files/new.html.erb
+++ b/app/views/report_files/new.html.erb
@@ -1,6 +1,13 @@
 <!-- app/views/report_files/new.html.erb -->
-<h1 class="text-lg font-semibold mb-2">Upload report</h1>
-<p class="text-sm text-slate-600 mb-4">Just drop a <b>statement</b> or <b>accounting</b> CSV — we <span class="font-semibold text-[color:var(--primary)]">auto‑detect</span> the report kind and parse it for you.</p>
+<div class="page-header">
+  <div>
+    <h1 class="page-title">Upload report</h1>
+    <p class="page-subtitle">Drop a <strong>statement</strong> or <strong>accounting</strong> CSV and we’ll auto-detect, parse, and feed it into your reconciliation queue.</p>
+  </div>
+  <div class="page-actions">
+    <%= link_to "Back to uploads", report_files_path, class: "btn btn-ghost" %>
+  </div>
+</div>
 
 <% if @file.errors.any? %>
   <div class="callout mb-6">
@@ -22,7 +29,7 @@
       <div>
         <label class="label">Reported on (optional)</label>
         <%= f.date_field :reported_on, class: "input mt-1", placeholder: Date.current.to_s %>
-        <p class="text-[11px] text-slate-500 mt-1">Defaults to today if left blank.</p>
+        <p class="text-[11px] text-[color:var(--text-muted)] mt-1">Defaults to today if left blank.</p>
       </div>
       <div>
         <label class="label">Currency (optional)</label>
@@ -34,7 +41,7 @@
       </div>
 
       <% if @file.kind.present? && @file.errors[:kind].blank? %>
-        <div class="md:col-span-2 flex items-center gap-2 text-xs text-slate-600">
+        <div class="md:col-span-2 flex items-center gap-2 text-xs text-[color:var(--text-muted)]">
           <span class="badge badge-muted">Detected kind: <span class="ml-1 font-medium"><%= @file.kind %></span></span>
           <%= f.hidden_field :kind %>
         </div>
@@ -42,7 +49,7 @@
         <div class="md:col-span-2">
           <label class="label">Report kind (manual override)</label>
           <%= f.select :kind, ReportFile.kinds.keys.map { |k| [k.humanize, k] }, { include_blank: "Auto (detect)" }, class: "select mt-1" %>
-          <p class="text-[11px] text-slate-500 mt-1">Normally auto-detected from headers. Choose one if detection failed.</p>
+          <p class="text-[11px] text-[color:var(--text-muted)] mt-1">Normally auto-detected from headers. Choose one if detection failed.</p>
         </div>
       <% end %>
     </div>

--- a/app/views/report_files/show.html.erb
+++ b/app/views/report_files/show.html.erb
@@ -1,54 +1,73 @@
 <!-- app/views/report_files/show.html.erb -->
-<h1 class="text-lg font-semibold mb-2">Report details</h1>
-<p class="text-sm text-slate-600 mb-6">
-  <strong>Kind:</strong> <span class="capitalize"><%= @file.kind %></span> ·
-  <strong>Status:</strong> <%= status_badge(@file.status) %> ·
-  <strong>Reported on:</strong> <%= @file.reported_on %>
-</p>
+<div class="page-header">
+  <div>
+    <h1 class="page-title">Report details</h1>
+    <p class="page-subtitle">
+      <strong>Kind:</strong> <span class="capitalize"><%= @file.kind %></span> ·
+      <strong>Status:</strong> <%= status_badge(@file.status) %> ·
+      <strong>Reported on:</strong> <%= @file.reported_on %>
+    </p>
+  </div>
+  <div class="page-actions">
+    <%= link_to "Back to uploads", report_files_path, class: "btn btn-ghost" %>
+  </div>
+</div>
 
-<div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-  <div class="card"><div class="text-xs uppercase tracking-wide text-slate-500">Original filename</div><div class="mt-1 font-mono text-sm break-all"><%= @file.original_filename || @file.file&.filename %></div></div>
-  <div class="card"><div class="text-xs uppercase tracking-wide text-slate-500">File size</div><div class="mt-1"><%= number_to_human_size(@file.bytes || @file.file&.byte_size) %></div></div>
-  <div class="card"><div class="text-xs uppercase tracking-wide text-slate-500">Rows created</div><div class="mt-1"><%= @stats[:rows_created] || (@file.statement? ? @file.statement_lines.count : @file.accounting_entries.count) %></div></div>
-  <div class="card"><div class="text-xs uppercase tracking-wide text-slate-500">Rows skipped</div><div class="mt-1"><%= @stats[:rows_skipped] || 0 %></div></div>
+<div class="stat-grid">
+  <div class="stat-card">
+    <span class="label">Original filename</span>
+    <span class="value font-mono text-sm break-all"><%= @file.original_filename || @file.file&.filename %></span>
+  </div>
+  <div class="stat-card">
+    <span class="label">File size</span>
+    <span class="value"><%= number_to_human_size(@file.bytes || @file.file&.byte_size) %></span>
+  </div>
+  <div class="stat-card">
+    <span class="label">Rows created</span>
+    <span class="value"><%= @stats[:rows_created] || (@file.statement? ? @file.statement_lines.count : @file.accounting_entries.count) %></span>
+  </div>
+  <div class="stat-card">
+    <span class="label">Rows skipped</span>
+    <span class="value"><%= @stats[:rows_skipped] || 0 %></span>
+  </div>
 </div>
 
 <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
   <div class="card">
-    <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">Currencies</div>
+    <div class="text-xs uppercase tracking-wide text-[color:var(--text-muted)] mb-1">Currencies</div>
     <% cur = Array(@stats[:currencies]) %>
     <% if cur.any? %>
       <div class="flex flex-wrap gap-2">
         <% cur.each do |c| %><span class="badge badge-muted"><%= c %></span><% end %>
       </div>
     <% else %>
-      <div class="text-sm text-slate-500">n/a</div>
+      <div class="text-sm text-[color:var(--text-muted)]">n/a</div>
     <% end %>
   </div>
   <div class="card">
-    <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">Elapsed (ms)</div>
+    <div class="text-xs uppercase tracking-wide text-[color:var(--text-muted)] mb-1">Elapsed (ms)</div>
     <div class="text-sm"><%= @stats[:elapsed_ms] || '—' %></div>
   </div>
   <div class="card">
-    <div class="text-xs uppercase tracking-wide text-slate-500 mb-1">Parse errors sample</div>
+    <div class="text-xs uppercase tracking-wide text-[color:var(--text-muted)] mb-1">Parse errors sample</div>
     <% errs = Array(@stats[:row_errors_sample]) %>
     <% if errs.any? %>
       <ul class="text-xs space-y-1 max-h-32 overflow-auto">
         <% errs.each do |e| %><li class="text-[11px] leading-tight"><%= e %></li><% end %>
       </ul>
     <% else %>
-      <div class="text-sm text-slate-500">none</div>
+      <div class="text-sm text-[color:var(--text-muted)]">none</div>
     <% end %>
   </div>
 </div>
 
 <% if @sample_lines.any? %>
-  <div class="card overflow-hidden p-0">
-    <div class="px-4 py-3 flex items-center justify-between border-b border-[color:var(--surface-border)] bg-[color:var(--muted-bg)]">
+  <div class="card">
+    <div class="flex items-center justify-between mb-3">
       <h2 class="text-sm font-semibold tracking-wide">Sample lines (<%= @sample_lines.size %>)</h2>
-      <span class="text-xs text-slate-500">Showing first 100 rows</span>
+      <span class="text-xs text-[color:var(--text-muted)]">Showing first 100 rows</span>
     </div>
-    <div class="overflow-x-auto">
+    <div class="table-wrap">
       <table class="table">
         <thead>
           <tr>
@@ -67,7 +86,7 @@
         <tbody>
         <% @sample_lines.each do |ln| %>
           <tr>
-            <td class="text-xs text-slate-500"><%= ln.line_no %></td>
+            <td class="text-xs text-[color:var(--text-muted)]"><%= ln.line_no %></td>
             <td><%= ln.occurred_on %></td>
             <td><%= ln.book_date %></td>
             <td><%= ln.respond_to?(:category) ? ln.category : '' %></td>


### PR DESCRIPTION
## Summary
- introduce a refreshed layout shell with a gradient top bar, flash styling, and updated tailwind-based component tokens
- modernize the uploads, exports, and reconciliation index pages with hero sections, empty states, and glassy data tables
- restyle detail and form views to use stat cards, callouts, and consistent actions for a cohesive reconciliation workflow

## Testing
- bin/rails test *(fails: missing gems in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cda61f03208321a7cadabcb750ddcc