### PR TITLE
Align statement totals with accounting captures

### DIFF
--- a/app/services/sources/statement.rb
+++ b/app/services/sources/statement.rb
@@ -22,6 +22,8 @@ module Sources
             OR (statement_lines.#{C::SL_CURRENCY} IS NULL OR statement_lines.#{C::SL_CURRENCY} = '')
                AND rf.#{C::RF_CURRENCY} = ?)
         SQL
+        .where("LOWER(statement_lines.#{C::SL_CATEGORY}) IN (?)", %w[payment platformpayment])
+        .where("LOWER(statement_lines.#{C::SL_TYPE}) = 'capture'")
         .sum(C::SL_AMOUNT) || 0
     end
   end

--- a/test/fixtures/files/sample_accounting.csv
+++ b/test/fixtures/files/sample_accounting.csv
@@ -1,0 +1,2 @@
+Category,Type,Status,Booking Date,Value Date,Currency,Amount
+platformPayment,Capture,Booked,2025-08-01,2025-08-01,USD,5663.97

--- a/test/fixtures/files/sample_statement.csv
+++ b/test/fixtures/files/sample_statement.csv
@@ -1,0 +1,4 @@
+Category,Type,Status,Transfer Id,Booking Date,Value Date,Currency,Amount,Starting Balance,Ending Balance
+platformPayment,Capture,Booked,TRX-CAP-1,2025-08-01,2025-08-01,USD,5663.97,,
+bank,bankTransfer,Booked,TRX-PAYOUT-1,2025-08-01,2025-08-01,USD,-3878.18,,
+bank,bankTransfer,Booked,TRX-PAYOUT-2,2025-08-02,2025-08-02,USD,-815.47,,

--- a/test/services/statement_accounting_reconciliation_test.rb
+++ b/test/services/statement_accounting_reconciliation_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class StatementAccountingReconciliationTest < ActiveSupport::TestCase
+  setup do
+    @credential = AdyenCredential.create!(label: "Test", auth_method: :password)
+  end
+
+  test "statement captures align with accounting captures" do
+    statement_rf = build_report_file(kind: :statement, reported_on: Date.new(2025, 8, 1))
+    attach_fixture(statement_rf, "sample_statement.csv")
+    Parse::Statement.call(statement_rf)
+
+    accounting_rf = build_report_file(kind: :accounting, reported_on: Date.new(2025, 8, 1))
+    attach_fixture(accounting_rf, "sample_accounting.csv")
+    Parse::Accounting.call(accounting_rf)
+
+    day_one = Date.new(2025, 8, 1)
+    day_two = Date.new(2025, 8, 2)
+
+    expected_capture_minor = 566_397
+
+    assert_equal expected_capture_minor, Sources::Accounting.total_for(nil, day_one, "USD")
+    assert_equal expected_capture_minor, Sources::Computed.total_for(nil, day_one, "USD")
+    assert_equal expected_capture_minor, Sources::Statement.total_for(nil, day_one, "USD")
+
+    assert_equal 0, Sources::Accounting.total_for(nil, day_two, "USD")
+    assert_equal 0, Sources::Computed.total_for(nil, day_two, "USD")
+    assert_equal 0, Sources::Statement.total_for(nil, day_two, "USD")
+
+    day_record = Recon::BuildDaily.new(account_scope: nil, date: day_one, currency: "USD").call
+    assert_equal expected_capture_minor, day_record.statement_total_cents
+    assert_equal expected_capture_minor, day_record.computed_total_cents
+    assert_equal :ok, day_record.status
+  end
+
+  private
+
+  def build_report_file(kind:, reported_on:)
+    ReportFile.create!(adyen_credential: @credential, kind: kind, reported_on: reported_on, currency: "USD")
+  end
+
+  def attach_fixture(report_file, filename)
+    path = Rails.root.join("test/fixtures/files", filename)
+    File.open(path) do |file|
+      report_file.file.attach(io: file, filename: filename, content_type: "text/csv")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add fixture CSV samples for statement and accounting reports
- cover reconciliation of parsed captures with a new service test
- filter statement source totals to platform payment capture rows so they match accounting

## Testing
- bin/rails test test/services/statement_accounting_reconciliation_test.rb *(fails: required gems missing in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaa6f6b548321aef677b3f33a45e6