### PR TITLE
Handle non-numeric balances when parsing statements

### DIFF
--- a/app/services/parse/statement.rb
+++ b/app/services/parse/statement.rb
@@ -177,7 +177,10 @@ module Parse
     # --- helpers ---
     def self.money_to_minor(val)
       return nil if val.nil? || val.to_s.strip.empty?
-      (Float(val.to_s.gsub(/[,]/,'')) * 100).round
+
+      (Float(val.to_s.gsub(/[,]/, "")) * 100).round
+    rescue ArgumentError, TypeError
+      nil
     end
 
     def self.safe_date(val)


### PR DESCRIPTION
## Summary
- tolerate non-numeric balance cells in statement parsing by rescuing conversion errors when normalising money values

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68ce0a3b10788321a2aee4d1cb56ebce