### PR TITLE
Support multi-file report uploads

### DIFF
--- a/app/controllers/report_files_controller.rb
+++ b/app/controllers/report_files_controller.rb
@@ -22,26 +22,58 @@ class ReportFilesController < ApplicationController
   end
 
   def create
-    @file = ReportFile.new(report_file_params.except(:file))
-    uploaded = report_file_params[:file]
+    permitted = report_file_params
+    uploads = Array.wrap(permitted[:file]).compact
+    base_attrs = permitted.except(:file)
 
-    # Attach file first so detection can use it
-    if uploaded.present?
-      Rails.logger.info("[ReportFiles#create] Received upload: original_filename=#{uploaded.original_filename} size=#{uploaded.size}")
-      @file.file.attach(uploaded)
-      Rails.logger.info("[ReportFiles#create] Attachment persisted?=#{@file.file.attached?}")
-      auto_detect_kind_if_needed(uploaded)
-    else
+    if uploads.blank?
+      @file = ReportFile.new(base_attrs)
       Rails.logger.warn("[ReportFiles#create] No file parameter provided")
+      @file.errors.add(:file, "must be attached")
+      ensure_default_credential!(@file)
+      @file.status ||= :pending
+      return render :new, status: :unprocessable_entity
     end
 
-    ensure_default_credential!
-
-    # Assign credential before validations
-    if @file.adyen_credential.blank?
-      @file.adyen_credential = AdyenCredential.first
-      Rails.logger.info("[ReportFiles#create] Assigned default credential id=#{@file.adyen_credential&.id}")
+    if uploads.one?
+      process_single_upload(uploads.first, base_attrs)
+    else
+      process_multiple_uploads(uploads, base_attrs)
     end
+  end
+
+  private
+
+  def ensure_default_credential!(file)
+    cred = AdyenCredential.first
+    unless cred
+      cred = AdyenCredential.create(label: "Default", auth_method: :password)
+      if cred.persisted?
+        Rails.logger.info("[ReportFiles#create] Created default AdyenCredential id=#{cred.id}")
+      else
+        Rails.logger.error("[ReportFiles#create] Failed to create default credential: #{cred.errors.full_messages.join(', ')}")
+      end
+    end
+
+    if file.adyen_credential.blank? && cred&.persisted?
+      file.adyen_credential = cred
+      Rails.logger.info("[ReportFiles#create] Assigned default credential id=#{file.adyen_credential&.id}")
+    end
+  end
+
+  def prepare_file_for_upload(file, uploaded)
+    return file unless uploaded.present?
+
+    Rails.logger.info("[ReportFiles#create] Received upload: original_filename=#{uploaded.original_filename} size=#{uploaded.size}")
+    file.file.attach(uploaded)
+    Rails.logger.info("[ReportFiles#create] Attachment persisted?=#{file.file.attached?}")
+    auto_detect_kind_if_needed(file, uploaded)
+    file
+  end
+
+  def process_single_upload(uploaded, base_attrs)
+    @file = prepare_file_for_upload(ReportFile.new(base_attrs), uploaded)
+    ensure_default_credential!(@file)
     @file.status ||= :pending
 
     if @file.kind.blank?
@@ -71,24 +103,73 @@ class ReportFilesController < ApplicationController
     end
   end
 
-  private
+  def process_multiple_uploads(uploads, base_attrs)
+    successes = []
+    failures = []
 
-  def ensure_default_credential!
-    return if AdyenCredential.exists?
-    cred = AdyenCredential.create(label: "Default", auth_method: :password)
-    if cred.persisted?
-      Rails.logger.info("[ReportFiles#create] Created default AdyenCredential id=#{cred.id}")
+    uploads.each do |uploaded|
+      file = prepare_file_for_upload(ReportFile.new(base_attrs), uploaded)
+      ensure_default_credential!(file)
+      file.status ||= :pending
+
+      if file.kind.blank?
+        file.errors.add(:kind, "could not be auto-detected; please choose (detection failed or low confidence)")
+        Rails.logger.warn("[ReportFiles#create] Kind undetected for #{uploaded.original_filename} – skipping")
+        failures << file
+        next
+      end
+
+      replacement_info = file.reported_on.present? ? prior_data_replacement_preview(file.kind, file.reported_on) : nil
+
+      if file.save
+        if replacement_info && replacement_info[:rows] > 0
+          replace_prior_data!(file.kind, file.reported_on)
+          Rails.logger.info("[ReportFiles#create] Replaced prior data kind=#{file.kind} day=#{file.reported_on} rows=#{replacement_info[:rows]}")
+        end
+        enqueue_parser(file)
+        successes << { file: file, replacement: replacement_info }
+      else
+        Rails.logger.error("[ReportFiles#create] Save failed for #{uploaded.original_filename}: #{file.errors.full_messages.join('; ')}")
+        failures << file
+      end
+    end
+
+    if failures.blank?
+      replaced_rows = successes.sum { |s| s[:replacement].to_h[:rows].to_i }
+      notice = "Upload received for #{successes.size} files. Parsing…"
+      notice += " Replaced #{replaced_rows} existing row(s)." if replaced_rows.positive?
+      redirect_to report_files_path, notice: notice
     else
-      Rails.logger.error("[ReportFiles#create] Failed to create default credential: #{cred.errors.full_messages.join(', ')}")
+      queued_count = successes.size
+      flash.now[:notice] = "Queued #{queued_count} file(s)." if queued_count.positive?
+      flash.now[:alert] = "#{failures.size} file(s) could not be queued. Review the errors below." if failures.size.positive?
+      @file = failures.first
+      render :new, status: :unprocessable_entity
     end
   end
 
   def report_file_params
-    params.require(:report_file).permit(:kind, :reported_on, :account_code, :account_id, :currency, :file)
+    raw = params.require(:report_file)
+    permitted = raw.permit(:kind, :reported_on, :account_code, :account_id, :currency)
+    uploads = raw[:file]
+    uploads = case uploads
+              when Array
+                uploads.compact
+              when ActionController::Parameters
+                uploads.to_unsafe_h.values.compact
+              when Hash
+                uploads.values.compact
+              when nil
+                []
+              else
+                [uploads]
+              end
+    permitted[:file] = uploads
+    permitted
   end
 
-  def auto_detect_kind_if_needed(uploaded)
-    return unless @file.kind.blank? && uploaded.respond_to?(:read)
+  def auto_detect_kind_if_needed(file, uploaded)
+    return unless file.kind.blank? && uploaded.respond_to?(:read)
     begin
       tf = uploaded.tempfile
       tf.rewind
@@ -113,12 +194,12 @@ class ReportFilesController < ApplicationController
 
       if detection[:detected].present?
         if detection[:exact]
-          @file.kind = detection[:detected]
+          file.kind = detection[:detected]
         else
           penalty = detection[:missing].size + detection[:unexpected].size + detection[:order_mismatches].size
           if penalty <= 4 # allow minor deviations
-            @file.kind = detection[:detected]
-            Rails.logger.info("[ReportFiles#create] Assigned kind=#{@file.kind} with minor header deviations (penalty=#{penalty})")
+            file.kind = detection[:detected]
+            Rails.logger.info("[ReportFiles#create] Assigned kind=#{file.kind} with minor header deviations (penalty=#{penalty})")
           else
             Rails.logger.warn("[ReportFiles#create] Ambiguous or severe header deviations (penalty=#{penalty}); requiring manual selection")
           end
@@ -128,10 +209,11 @@ class ReportFilesController < ApplicationController
       end
 
       # Add validation message if deviations severe and kind assigned
-      if @file.kind.present? && !detection[:exact]
+      if file.kind.present? && !detection[:exact]
         significant = detection[:missing].any? || detection[:unexpected].any? || detection[:order_mismatches].any?
         if significant
-          @file.errors.add(:base, "Headers deviated from expected #{detection[:detected]} format. Missing: #{detection[:missing].join('; ')} Unexpected: #{detection[:unexpected].take(5).join('; ')}") if penalty > 4
+          penalty = detection[:missing].size + detection[:unexpected].size + detection[:order_mismatches].size
+          file.errors.add(:base, "Headers deviated from expected #{detection[:detected]} format. Missing: #{detection[:missing].join('; ')} Unexpected: #{detection[:unexpected].take(5).join('; ')}") if penalty > 4
         end
       end
     rescue => e

--- a/app/views/report_files/new.html.erb
+++ b/app/views/report_files/new.html.erb
@@ -36,8 +36,9 @@
         <%= f.text_field :currency, placeholder: "USD", class: "input mt-1" %>
       </div>
       <div class="md:col-span-2">
-        <label class="label">CSV file</label>
-        <%= f.file_field :file, class: "input mt-1" %>
+        <label class="label">CSV files</label>
+        <%= f.file_field :file, multiple: true, class: "input mt-1" %>
+        <p class="text-[11px] text-[color:var(--text-muted)] mt-1">Select one or more report files to queue them all at once.</p>
       </div>
 
       <% if @file.kind.present? && @file.errors[:kind].blank? %>

--- a/test/controllers/report_files_controller_test.rb
+++ b/test/controllers/report_files_controller_test.rb
@@ -1,23 +1,44 @@
 require "test_helper"
 
 class ReportFilesControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get report_files_index_url
-    assert_response :success
+  include ActiveJob::TestHelper
+
+  setup do
+    clear_enqueued_jobs
   end
 
-  test "should get show" do
-    get report_files_show_url
-    assert_response :success
+  teardown do
+    clear_enqueued_jobs
   end
 
-  test "should get new" do
-    get report_files_new_url
-    assert_response :success
+  test "queues a single upload and redirects to show" do
+    file = fixture_file_upload("files/sample_statement.csv", "text/csv")
+
+    assert_difference -> { ReportFile.count }, 1 do
+      assert_enqueued_with(job: ParseBalanceStatementJob) do
+        post report_files_path, params: { report_file: { file: [file] } }, as: :multipart
+      end
+    end
+
+    report_file = ReportFile.order(:created_at).last
+    assert_redirected_to report_file_path(report_file)
+    assert_equal "statement", report_file.kind
+    assert_equal "pending", report_file.status
   end
 
-  test "should get create" do
-    get report_files_create_url
-    assert_response :success
+  test "queues multiple uploads and redirects to index" do
+    statement = fixture_file_upload("files/sample_statement.csv", "text/csv")
+    accounting = fixture_file_upload("files/sample_accounting.csv", "text/csv")
+
+    assert_enqueued_jobs 2, only: [ParseBalanceStatementJob, ParseAccountingReportJob] do
+      assert_difference -> { ReportFile.count }, 2 do
+        post report_files_path, params: { report_file: { file: [statement, accounting] } }, as: :multipart
+      end
+    end
+
+    assert_redirected_to report_files_path
+    kinds = ReportFile.order(:created_at).last(2).map(&:kind)
+    assert_includes kinds, "statement"
+    assert_includes kinds, "accounting"
   end
 end


### PR DESCRIPTION
## Summary
- allow uploading multiple report CSV files in a single request and fan out processing server-side
- ensure default credentials and header detection run per file while reporting partial failures
- update the upload form helper text and add controller tests that cover single and bulk uploads

## Testing
- ⚠️ `bin/rails test test/controllers/report_files_controller_test.rb` *(fails: missing gems because Bundler cannot install dependencies due to 403 Forbidden from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1bdd5fe48321bd466dd6c524adb4