### PR TITLE
Fix upload spinner and turbo status updates

### DIFF
--- a/app/javascript/controllers/multi_upload_controller.js
+++ b/app/javascript/controllers/multi_upload_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
     if (!input) return
 
     const count = input.files ? input.files.length : 0
-    if (count > 1) {
+    if (count > 0) {
       this.showSpinner(count)
     } else {
       this.reset()

--- a/app/models/report_file.rb
+++ b/app/models/report_file.rb
@@ -109,14 +109,14 @@ class ReportFile < ApplicationRecord
   def broadcast_status_refresh
     status_dom_id = dom_id(self, :status)
 
-    Turbo::StreamsChannel.broadcast_replace_later_to(
+    Turbo::StreamsChannel.broadcast_update_later_to(
       :report_files,
       target: status_dom_id,
       partial: "report_files/status_badge",
       locals: { file: self }
     )
 
-    Turbo::StreamsChannel.broadcast_replace_later_to(
+    Turbo::StreamsChannel.broadcast_update_later_to(
       self,
       target: status_dom_id,
       partial: "report_files/status_badge",


### PR DESCRIPTION
## Summary
- ensure the multi-upload Stimulus controller always shows the progress spinner when files are submitted
- switch report file status broadcasts to use turbo stream updates so frames keep refreshing without a manual reload

## Testing
- bin/rails test *(fails: missing required gems in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2a23f81c8321b2db772bbac552e7