### PR TITLE
Ensure report status updates broadcast latest state

### DIFF
--- a/app/assets/stylesheets/ui.css
+++ b/app/assets/stylesheets/ui.css
@@ -43,6 +43,14 @@ body::before {
   border-radius: .75rem;
 }
 
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.animate-spin {
+  animation: spin .8s linear infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   * { transition: none !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
 }

--- a/app/models/report_file.rb
+++ b/app/models/report_file.rb
@@ -107,6 +107,7 @@ class ReportFile < ApplicationRecord
   end
 
   def broadcast_status_refresh
+    reload
     status_dom_id = dom_id(self, :status)
 
     Turbo::StreamsChannel.broadcast_update_later_to(


### PR DESCRIPTION
## Summary
- ensure report file status broadcasts reload the record so turbo frames render the latest badge state
- add a reusable spin animation utility so pending status badges display the animated loader

## Testing
- bin/rails test *(fails: missing locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2b6a39c48321a84640456ffff786