### PR TITLE
Allow nil account scope for fee breakdowns

### DIFF
--- a/app/models/fee_breakdown.rb
+++ b/app/models/fee_breakdown.rb
@@ -1,5 +1,6 @@
 class FeeBreakdown < ApplicationRecord
-  validates :account_scope, :date, :currency, presence: true
+  validates :date, :currency, presence: true
+  validates :account_scope, presence: true, unless: -> { account_scope.nil? }
 
   def total!
     self.total_fees_cents = %i[

--- a/db/migrate/20250919020000_allow_null_on_fee_breakdowns_account_scope.rb
+++ b/db/migrate/20250919020000_allow_null_on_fee_breakdowns_account_scope.rb
@@ -1,0 +1,5 @@
+class AllowNullOnFeeBreakdownsAccountScope < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :fee_breakdowns, :account_scope, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -113,7 +113,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_19_012406) do
   end
 
   create_table "fee_breakdowns", force: :cascade do |t|
-    t.string "account_scope", null: false
+    t.string "account_scope"
     t.date "date", null: false
     t.string "currency", null: false
     t.bigint "scheme_fees_cents", default: 0


### PR DESCRIPTION
## Summary
- allow fee breakdowns to be saved for nil account scopes while still rejecting blank strings
- add a migration and schema update so fee_breakdowns.account_scope allows NULL values

## Testing
- `bin/rails db:migrate` *(fails: missing gems in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2d4b8cc88321a1c2274d0dd7fbfc