### PR TITLE
Add currency column to reconciliation list

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,8 +17,23 @@ module ApplicationHelper
     content_tag(:span, label, class: css)
   end
 
-    def money_minor(cents, currency)
-      number_to_currency((cents.to_i) / 100.0, unit: currency)
+    def money_minor(cents, currency, include_unit: true)
+      unit = include_unit ? currency : ""
+      number_to_currency((cents.to_i) / 100.0, unit: unit)
+    end
+
+    def currency_with_icon(currency)
+      return "" if currency.blank?
+
+      icon = case currency
+             when "EUR" then "💶"
+             when "USD" then "💵"
+             when "GBP" then "💷"
+             when "JPY" then "💴"
+             else "💱"
+             end
+
+      "#{currency} #{icon}"
     end
 
   # Convert integer minor units to decimal currency

--- a/app/views/reconciliations/index.html.erb
+++ b/app/views/reconciliations/index.html.erb
@@ -74,6 +74,7 @@
       <thead>
       <tr>
         <th>Date</th>
+        <th>Currency</th>
         <th>Statement</th>
         <th>Accounting</th>
         <th>Computed</th>
@@ -86,10 +87,11 @@
       <% @days.each do |day| %>
         <tr>
           <td><%= day.date %></td>
-          <td><%= money_minor(day.statement_total_cents, day.currency) %></td>
-          <td><%= money_minor(day.accounting_total_cents, day.currency) %></td>
-          <td><%= money_minor(day.computed_total_cents, day.currency) %></td>
-          <td><%= money_minor(day.variance_cents, day.currency) %></td>
+          <td><%= currency_with_icon(day.currency) %></td>
+          <td><%= money_minor(day.statement_total_cents, day.currency, include_unit: false) %></td>
+          <td><%= money_minor(day.accounting_total_cents, day.currency, include_unit: false) %></td>
+          <td><%= money_minor(day.computed_total_cents, day.currency, include_unit: false) %></td>
+          <td><%= money_minor(day.variance_cents, day.currency, include_unit: false) %></td>
           <td>
           <span class="badge <%= { "ok"=>"badge-success", "warn"=>"badge-muted", "error"=>"badge-error" }[day.status] %>">
             <%= day.status %>


### PR DESCRIPTION
## Summary
- add a currency column to the reconciliation days table and display an emoji with the ISO code
- allow monetary helper to optionally omit the currency unit so table amounts show only numbers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cec203c8a8832192883e45fba59e15