### PR TITLE
Implement fee intelligence categorization

### DIFF
--- a/app/services/sources/config.rb
+++ b/app/services/sources/config.rb
@@ -30,6 +30,9 @@ module Sources
     AE_AMOUNT    = "amount_minor"
     AE_CATEGORY  = "category"
     AE_TYPE      = "type"
+    AE_SUBCATEGORY = "subcategory"
+    AE_REFERENCE   = "reference"
+    AE_DESCRIPTION = "description"
 
     # Enum names (Ruby-level). We'll resolve to integers safely.
     KIND_STATEMENT  = "statement"

--- a/app/services/sources/fees.rb
+++ b/app/services/sources/fees.rb
@@ -7,18 +7,126 @@ module Sources
     include Config
     extend Helpers
 
-    # With current samples, there are no obvious "fee" rows yet.
-    # We return zeros (and you’ll see "No fee data" or all 0 in the UI).
-    # Once fee categories start appearing, wire rules below (match on category/type substrings).
     def self.for(scope, date, currency)
-      {
-        scheme: 0,
-        processing: 0,
-        interchange: 0,
-        chargeback: 0,
-        payout: 0,
-        other: 0
-      }
+      return EMPTY.dup unless Config::AccountingEntry && Config::ReportFile
+
+      rf_kind = ReportFile.kinds[Config::KIND_ACCOUNTING]
+
+      base = Config::AccountingEntry
+               .joins("INNER JOIN report_files rf ON rf.id = accounting_entries.#{Config::AE_FILE_ID}")
+               .where("rf.#{Config::RF_KIND} = ?", rf_kind)
+               .yield_self do |rel|
+                 if scope.nil?
+                   rel.where("rf.#{Config::RF_SCOPE} IS NULL")
+                 else
+                   rel.where("rf.#{Config::RF_SCOPE} = ?", scope)
+                 end
+               end
+               .where("accounting_entries.#{Config::AE_BOOK_DATE} = ?", date)
+               .where(<<~SQL, currency, currency)
+                 (accounting_entries.#{Config::AE_CURRENCY} = ?
+                   OR (accounting_entries.#{Config::AE_CURRENCY} IS NULL OR accounting_entries.#{Config::AE_CURRENCY} = '')
+                      AND rf.#{Config::RF_CURRENCY} = ?)
+               SQL
+               .where.not("accounting_entries.#{Config::AE_AMOUNT} IS NULL")
+
+      totals = EMPTY.dup
+
+      base.pluck(
+        "accounting_entries.#{Config::AE_AMOUNT}",
+        "accounting_entries.#{Config::AE_CATEGORY}",
+        "accounting_entries.#{Config::AE_TYPE}",
+        "accounting_entries.#{Config::AE_SUBCATEGORY}",
+        "accounting_entries.#{Config::AE_REFERENCE}",
+        "accounting_entries.#{Config::AE_DESCRIPTION}"
+      ).each do |amount, category, type, subcategory, reference, description|
+        next if amount.nil?
+
+        bucket = bucket_for(category, type, subcategory, reference, description)
+        next unless bucket
+
+        totals[bucket] += amount.to_i
+      end
+
+      totals
+    end
+
+    EMPTY = {
+      scheme: 0,
+      processing: 0,
+      interchange: 0,
+      chargeback: 0,
+      payout: 0,
+      other: 0
+    }.freeze
+
+    private_constant :EMPTY
+
+    def self.bucket_for(category, type, subcategory, reference, description)
+      values = [category, type, subcategory, reference, description].compact
+      values.reject! { |v| v.to_s.strip.empty? }
+      return nil if values.empty?
+
+      raw = values.map { |v| v.to_s.downcase }.join(" ")
+      normalized = raw.gsub(/[^a-z0-9]+/, " ")
+      haystack = "#{raw} #{normalized}".squeeze(" ")
+
+      return :chargeback if chargeback_fee?(haystack, category)
+      return :interchange if haystack.include?("interchange")
+      return :scheme if scheme_fee?(haystack)
+      return :processing if processing_fee?(haystack)
+      return :payout if payout_fee?(haystack, category)
+      return :other if other_fee?(haystack)
+
+      nil
+    end
+
+    private_class_method :bucket_for
+
+    private_class_method def self.chargeback_fee?(haystack, category)
+      (haystack.include?("chargeback") && (haystack.include?("fee") || haystack.include?("cost") || haystack.include?("commission") || haystack.include?("penalty"))) ||
+        (category.to_s == "chargeback" && (haystack.include?("fee") || haystack.include?("cost") || haystack.include?("commission")))
+    end
+
+    private_class_method def self.scheme_fee?(haystack)
+      haystack.include?("scheme fee") ||
+        haystack.include?("schemefee") ||
+        haystack.include?("network fee") ||
+        haystack.include?("assessment")
+    end
+
+    private_class_method def self.processing_fee?(haystack)
+      haystack.include?("processing fee") ||
+        haystack.include?("processingfee") ||
+        haystack.include?("psp fee") ||
+        haystack.include?("pspfee") ||
+        haystack.include?("commission") ||
+        haystack.include?("markup") ||
+        haystack.include?("mark up") ||
+        haystack.include?("mark-up") ||
+        haystack.include?("payment fee") ||
+        haystack.include?("platform fee") ||
+        haystack.include?("service fee") ||
+        haystack.include?("gateway fee") ||
+        haystack.include?("transaction fee") ||
+        haystack.include?("acquirer fee")
+    end
+
+    private_class_method def self.payout_fee?(haystack, category)
+      haystack.include?("payout fee") ||
+        haystack.include?("payoutfee") ||
+        haystack.include?("payout cost") ||
+        haystack.include?("cashout fee") ||
+        haystack.include?("withdrawal fee") ||
+        haystack.include?("bank transfer fee") ||
+        haystack.include?("banktransferfee") ||
+        haystack.include?("sepa fee") ||
+        haystack.include?("swift fee") ||
+        (category.to_s == "bank" && haystack.include?("fee"))
+    end
+
+    private_class_method def self.other_fee?(haystack)
+      haystack.include?("fee") || haystack.include?("cost") || haystack.include?("levy") || haystack.include?("assessment")
     end
   end
 end

--- a/test/services/sources/fees_test.rb
+++ b/test/services/sources/fees_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+
+module Sources
+  class FeesTest < ActiveSupport::TestCase
+    setup do
+      @date = Date.new(2025, 8, 25)
+      @credential = AdyenCredential.create!(label: "Test", auth_method: :password)
+      @report_file = ReportFile.create!(
+        adyen_credential: @credential,
+        kind: :accounting,
+        reported_on: @date,
+        currency: "USD"
+      )
+      @line_no = 0
+    end
+
+    test "categorizes accounting entries into fee buckets" do
+      create_entry(amount: -150, category: "platformpayment", type: "scheme fee", description: "Visa scheme fee")
+      create_entry(amount: -275, category: "platformpayment", type: "commission", description: "Processing fee")
+      create_entry(amount: -125, category: "platformpayment", type: "interchange", description: "Interchange fee")
+      create_entry(amount: -300, category: "chargeback", type: "fee", description: "Chargeback fee")
+      create_entry(amount: -95, category: "bank", type: "banktransfer", description: "Bank transfer fee")
+      create_entry(amount: -60, category: "platformpayment", type: "adjustment", description: "Regulatory fee")
+
+      result = Sources::Fees.for(nil, @date, "USD")
+
+      assert_equal(-150, result[:scheme])
+      assert_equal(-275, result[:processing])
+      assert_equal(-125, result[:interchange])
+      assert_equal(-300, result[:chargeback])
+      assert_equal(-95, result[:payout])
+      assert_equal(-60, result[:other])
+    end
+
+    test "ignores non fee accounting entries" do
+      create_entry(amount: 5_000, category: "platformpayment", type: "capture", description: "Successful capture")
+
+      result = Sources::Fees.for(nil, @date, "USD")
+
+      assert_equal({
+        scheme: 0,
+        processing: 0,
+        interchange: 0,
+        chargeback: 0,
+        payout: 0,
+        other: 0
+      }, result)
+    end
+
+    test "filters by scope and uses currency fallback" do
+      scoped_report = ReportFile.create!(
+        adyen_credential: @credential,
+        kind: :accounting,
+        reported_on: @date,
+        currency: "USD",
+        account_code: "SCOPE-123"
+      )
+
+      create_entry(amount: -200, category: "platformpayment", type: "commission", description: "Processing fee")
+      create_entry(amount: -80, category: "bank", type: "fee", description: "Payout fee", report_file: scoped_report, currency: nil)
+
+      nil_scope_result = Sources::Fees.for(nil, @date, "USD")
+      scoped_result = Sources::Fees.for("SCOPE-123", @date, "USD")
+
+      assert_equal(-200, nil_scope_result[:processing])
+      assert_equal(0, nil_scope_result[:payout])
+
+      assert_equal(-80, scoped_result[:payout])
+      assert_equal(0, scoped_result[:processing])
+    end
+
+    private
+
+    def create_entry(amount:, category:, type:, description:, subcategory: nil, report_file: @report_file, currency: "USD")
+      @line_no += 1
+
+      AccountingEntry.create!(
+        report_file: report_file,
+        line_no: @line_no,
+        occurred_on: @date,
+        book_date: @date,
+        category: category,
+        type: type,
+        subcategory: subcategory,
+        status: "booked",
+        amount_minor: amount,
+        currency: currency,
+        reference: nil,
+        description: description
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add column constants so fee extraction can read accounting entry metadata
- implement Sources::Fees to bucket accounting entries by scheme, processing, interchange, chargeback, payout, and other fee types
- cover the new matching logic with unit tests for fee categorization, scope filtering, and currency fallback

## Testing
- bundle exec rails test test/services/sources/fees_test.rb *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_68cec361a968832196aab56544d2710d