### PR TITLE
Highlight payouts in reconciliation list

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,24 +17,27 @@ module ApplicationHelper
     content_tag(:span, label, class: css)
   end
 
-    def money_minor(cents, currency, include_unit: true)
-      unit = include_unit ? currency : ""
-      number_to_currency((cents.to_i) / 100.0, unit: unit)
-    end
+  def money_minor(cents, currency, include_unit: true)
+    unit = include_unit ? currency : ""
+    number_to_currency((cents.to_i) / 100.0, unit: unit)
+  end
 
-    def currency_with_icon(currency)
-      return "" if currency.blank?
+  def currency_with_icon(currency, payout: false)
+    return "" if currency.blank?
 
-      icon = case currency
-             when "EUR" then "💶"
-             when "USD" then "💵"
-             when "GBP" then "💷"
-             when "JPY" then "💴"
-             else "💱"
-             end
+    icon = case currency
+           when "EUR" then "💶"
+           when "USD" then "💵"
+           when "GBP" then "💷"
+           when "JPY" then "💴"
+           else "💱"
+           end
 
-      "#{currency} #{icon}"
-    end
+    pieces = ["#{currency} #{icon}"]
+    pieces << "🏦" if payout
+
+    pieces.join(" ")
+  end
 
   # Convert integer minor units to decimal currency
   def minor_to_amount(minor, currency = nil)

--- a/app/views/reconciliations/index.html.erb
+++ b/app/views/reconciliations/index.html.erb
@@ -87,7 +87,7 @@
       <% @days.each do |day| %>
         <tr>
           <td><%= day.date %></td>
-          <td><%= currency_with_icon(day.currency) %></td>
+          <td><%= currency_with_icon(day.currency, payout: @payout_lookup&.[]([day.account_scope, day.date, day.currency])) %></td>
           <td><%= money_minor(day.statement_total_cents, day.currency, include_unit: false) %></td>
           <td><%= money_minor(day.accounting_total_cents, day.currency, include_unit: false) %></td>
           <td><%= money_minor(day.computed_total_cents, day.currency, include_unit: false) %></td>


### PR DESCRIPTION
## Summary
- preload payout match data when building the reconciliation list
- show a bank icon next to currencies that have payouts on that day

## Testing
- bundle exec rubocop *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cec721f740832190e390bfd3eba707