### PR TITLE
Show bank indicator when payout matches exist

### DIFF
--- a/test/controllers/reconciliations_controller_test.rb
+++ b/test/controllers/reconciliations_controller_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class ReconciliationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @date = Date.new(2025, 8, 6)
+    @day = ReconciliationDay.create!(
+      account_scope: nil,
+      date: @date,
+      currency: "USD",
+      statement_total_cents: 3_168_509,
+      accounting_total_cents: 9_510_159,
+      computed_total_cents: 3_168_509,
+      variance_cents: 0,
+      status: :ok
+    )
+  end
+
+  test "shows bank icon when payout matches exist" do
+    PayoutMatch.create!(
+      account_scope: nil,
+      payout_date: @date,
+      currency: "USD",
+      adyen_payout_id: "PO123",
+      adyen_amount_cents: 100,
+      status: :unmatched
+    )
+
+    get reconciliations_path
+
+    assert_response :success
+    assert_includes response.body, "USD 💵 🏦"
+  end
+
+  test "omits bank icon when payout matches are absent" do
+    get reconciliations_path
+
+    assert_response :success
+    assert_includes response.body, "USD 💵"
+    refute_includes response.body, "USD 💵 🏦"
+  end
+end


### PR DESCRIPTION
## Summary
- compute the payout indicator for reconciliation rows using stored PayoutMatch records so the bank icon appears when bank transfers exist
- add controller integration tests covering the presence or absence of the bank icon on the reconciliation list

## Testing
- `bundle exec rails test test/controllers/reconciliations_controller_test.rb` *(fails: bundler could not find installed gems in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ced78dfbb083218fccb09a03c8f5fd