### PR TITLE
Fix bank indicator detection for reconciliation list

### DIFF
--- a/test/controllers/reconciliations_controller_test.rb
+++ b/test/controllers/reconciliations_controller_test.rb
@@ -15,14 +15,12 @@ class ReconciliationsControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
-  test "shows bank icon when payout matches exist" do
-    PayoutMatch.create!(
-      account_scope: nil,
-      payout_date: @date,
+  test "shows bank icon when payout records exist" do
+    Payout.create!(
+      booked_on: @date,
       currency: "USD",
-      adyen_payout_id: "PO123",
-      adyen_amount_cents: 100,
-      status: :unmatched
+      amount_minor: 100,
+      status: "booked"
     )
 
     get reconciliations_path
@@ -31,7 +29,7 @@ class ReconciliationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "USD 💵 🏦"
   end
 
-  test "omits bank icon when payout matches are absent" do
+  test "omits bank icon when payout records are absent" do
     get reconciliations_path
 
     assert_response :success


### PR DESCRIPTION
## Summary
- derive the bank transfer flag on reconciliation rows from payout records instead of payout matches
- resolve the payout lookup by inspecting report file scope and currency for each payout
- update controller tests to exercise the new payout-driven indicator logic

## Testing
- bin/rails test test/controllers/reconciliations_controller_test.rb *(fails: missing gems and bundle install blocked by 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cedac3db8c832194912953632d2105