### PR TITLE
Fix payout icon detection for lowercase payout currencies

### DIFF
--- a/app/controllers/reconciliations_controller.rb
+++ b/app/controllers/reconciliations_controller.rb
@@ -39,6 +39,7 @@ class ReconciliationsController < ApplicationController
       if date_keys.any? && currency_filter.any?
         Payout.includes(:source_report_file).where(booked_on: date_keys).find_each do |payout|
           resolved_currency = payout.currency.presence || payout.source_report_file&.currency
+          resolved_currency = resolved_currency&.upcase
           next unless resolved_currency && currency_filter.include?(resolved_currency)
 
           scope = payout.source_report_file&.account_code.presence

--- a/test/controllers/reconciliations_controller_test.rb
+++ b/test/controllers/reconciliations_controller_test.rb
@@ -29,6 +29,20 @@ class ReconciliationsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "USD 💵 🏦"
   end
 
+  test "shows bank icon when payout currency is lowercase" do
+    Payout.create!(
+      booked_on: @date,
+      currency: "usd",
+      amount_minor: 100,
+      status: "booked"
+    )
+
+    get reconciliations_path
+
+    assert_response :success
+    assert_includes response.body, "USD 💵 🏦"
+  end
+
   test "omits bank icon when payout records are absent" do
     get reconciliations_path
 


### PR DESCRIPTION
## Summary
- ensure payout currencies are normalized to uppercase when building the lookup used for icons
- add a controller test covering payouts stored with lowercase currency codes

## Testing
- `bin/rails test test/controllers/reconciliations_controller_test.rb` *(fails: missing gems; bundler install blocked by 403 from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3ad985288321ad2f52ab1130dd99