### PR TITLE
Add payout transactions modal for reconciliation payout matches

### DIFF
--- a/app/assets/stylesheets/ui.css
+++ b/app/assets/stylesheets/ui.css
@@ -258,6 +258,49 @@ body::before {
   background: color-mix(in srgb, var(--surface) 90%, transparent);
   border: 1px dashed color-mix(in srgb, var(--surface-border) 80%, transparent);
 }
+
+/* Modals */
+dialog.modal {
+  border: none;
+  padding: 0;
+  border-radius: 1.5rem;
+  width: min(92vw, 42rem);
+  background: color-mix(in srgb, var(--surface) 95%, transparent);
+  color: var(--text);
+  box-shadow: 0 30px 60px -28px rgba(15,23,42,0.55);
+}
+
+dialog.modal::backdrop {
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem 0;
+}
+
+.modal__body {
+  padding: 1.25rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -.01em;
+}
+
+.modal__meta {
+  margin: 0;
+  font-size: .8rem;
+  color: color-mix(in srgb, var(--text-muted) 80%, transparent);
+}
 .empty-state i {
   display: inline-flex;
   width: 3rem;

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Controls native dialog modals for payout transaction details
+export default class extends Controller {
+  static targets = ["dialog"]
+
+  open(event) {
+    event.preventDefault()
+    if (!this.hasDialogTarget) return
+
+    const dialog = this.dialogTarget
+    if (typeof dialog.showModal === "function") {
+      dialog.showModal()
+    } else {
+      dialog.setAttribute("open", "open")
+    }
+  }
+
+  close(event) {
+    event.preventDefault()
+    if (!this.hasDialogTarget) return
+
+    const dialog = this.dialogTarget
+    if (dialog.open) {
+      dialog.close()
+    } else {
+      dialog.removeAttribute("open")
+    }
+  }
+
+  backdrop(event) {
+    if (!this.hasDialogTarget) return
+    if (event.target !== event.currentTarget) return
+
+    this.close(event)
+  }
+}

--- a/app/services/recon/payout_matcher.rb
+++ b/app/services/recon/payout_matcher.rb
@@ -17,21 +17,103 @@ module Recon
       scope_matches.delete_all
 
       adyen_payouts.each do |p|
-        match = @bank_lines.find { |b| b[:currency] == p[:currency] && b[:amount_cents].to_i == p[:amount_cents].to_i && (b[:date] - p[:date]).abs <= 2 }
-        status, details = if match
-                            [:matched, { bank_ref: match[:ref], bank_amount_cents: match[:amount_cents] }]
-                          else
-                            [:unmatched, {}]
-                          end
         payout_currency = p[:currency] || @currency_filter
+        capture_result = capture_transactions_until(payout_date: p[:date], currency: payout_currency)
+        transactions = capture_result[:transactions]
+
+        transactions_total = transactions.sum { |tx| tx[:amount_cents].to_i }
+        payout_amount = p[:amount_cents].to_i.abs
+
+        match = @bank_lines.find do |b|
+          b[:currency] == payout_currency &&
+            b[:amount_cents].to_i == p[:amount_cents].to_i &&
+            (b[:date] - p[:date]).abs <= 2
+        end
+
+        details = {}
+        details[:bank_ref] = match[:ref] if match
+        details[:transactions] = transactions
+        details[:transactions_total_cents] = transactions_total
+        details[:transactions_period_start] = capture_result[:period_start]&.to_s
+
+        status = if payout_amount == transactions_total
+                   :matched
+                 elsif transactions_total.zero?
+                   :unmatched
+                 else
+                   :partial
+                 end
 
         PayoutMatch.create!(
-          account_scope: @scope, payout_date: p[:date], currency: payout_currency,
-          adyen_payout_id: p[:id], adyen_amount_cents: p[:amount_cents],
-          bank_ref: details[:bank_ref], bank_amount_cents: details[:bank_amount_cents],
-          status:, details: details.except(:bank_amount_cents)
+          account_scope: @scope,
+          payout_date: p[:date],
+          currency: payout_currency,
+          adyen_payout_id: p[:id],
+          adyen_amount_cents: p[:amount_cents],
+          bank_ref: match&.[](:ref),
+          bank_amount_cents: match&.[](:amount_cents),
+          status:,
+          details: details
         )
       end
+    end
+
+    private
+
+    def capture_transactions_until(payout_date:, currency:)
+      stmt_model = Sources::Config::StatementLine
+      return { transactions: [], period_start: nil } unless stmt_model
+
+      relation = stmt_model.joins("INNER JOIN report_files rf ON rf.id = statement_lines.#{Sources::Config::SL_FILE_ID}")
+      relation = if @scope.nil?
+                   relation.where("COALESCE(rf.#{Sources::Config::RF_SCOPE}, '') = ''")
+                 else
+                   relation.where("rf.#{Sources::Config::RF_SCOPE} = ?", @scope)
+                 end
+
+      relation = relation.where(<<~SQL, currency, currency)
+        (statement_lines.#{Sources::Config::SL_CURRENCY} = ?
+          OR (statement_lines.#{Sources::Config::SL_CURRENCY} IS NULL OR statement_lines.#{Sources::Config::SL_CURRENCY} = '')
+             AND rf.#{Sources::Config::RF_CURRENCY} = ?)
+      SQL
+
+      relation = relation.where("LOWER(statement_lines.#{Sources::Config::SL_CATEGORY}) IN (?)", %w[payment platformpayment])
+                         .where("LOWER(statement_lines.#{Sources::Config::SL_TYPE}) = 'capture'")
+
+      previous_date = previous_payout_date(payout_date:, currency:)
+
+      relation = relation.where("statement_lines.#{Sources::Config::SL_BOOK_DATE} <= ?", payout_date)
+      relation = relation.where("statement_lines.#{Sources::Config::SL_BOOK_DATE} > ?", previous_date) if previous_date
+
+      rows = relation.order("statement_lines.#{Sources::Config::SL_BOOK_DATE} ASC, statement_lines.line_no ASC")
+                      .pluck(Sources::Config::SL_BOOK_DATE, "statement_lines.reference", Sources::Config::SL_AMOUNT)
+
+      transactions = rows.map do |date, reference, amount|
+        {
+          date: date&.to_s,
+          reference: reference,
+          amount_cents: amount.to_i
+        }
+      end
+
+      { transactions:, period_start: previous_date }
+    end
+
+    def previous_payout_date(payout_date:, currency:)
+      payout_model = Sources::Config::PayoutModel
+      return nil unless payout_model
+
+      relation = payout_model.left_joins(:source_report_file)
+      relation = if @scope.nil?
+                   relation.where("COALESCE(report_files.#{Sources::Config::RF_SCOPE}, '') = ''")
+                 else
+                   relation.where("report_files.#{Sources::Config::RF_SCOPE} = ?", @scope)
+                 end
+
+      relation = relation.where("COALESCE(payouts.currency, report_files.#{Sources::Config::RF_CURRENCY}) = ?", currency)
+      relation = relation.where("payouts.booked_on < ?", payout_date)
+
+      relation.order(booked_on: :desc).limit(1).pick(:booked_on)
     end
   end
 end

--- a/app/views/reconciliations/show.html.erb
+++ b/app/views/reconciliations/show.html.erb
@@ -89,14 +89,78 @@
   <% else %>
     <div class="table-wrap">
       <table class="table">
-        <thead><tr><th>Adyen payout</th><th>Bank ref</th><th>Amount</th><th>Status</th></tr></thead>
+        <thead><tr><th>Adyen payout</th><th>Bank ref</th><th>Amount</th><th>Transactions</th></tr></thead>
         <tbody>
         <% @payouts.each do |p| %>
+          <% details = p.details.respond_to?(:deep_symbolize_keys) ? p.details.deep_symbolize_keys : {} %>
+          <% transactions = Array(details[:transactions]) %>
+          <% transactions_total = details[:transactions_total_cents].to_i %>
+          <% period_start = details[:transactions_period_start].presence && (Date.parse(details[:transactions_period_start]) rescue nil) %>
+          <% period_end = p.payout_date %>
+          <% heading_id = "#{dom_id(p, :transactions)}_heading" %>
           <tr>
             <td class="font-mono text-xs"><%= p.adyen_payout_id %></td>
             <td class="font-mono text-xs"><%= p.bank_ref || "—" %></td>
             <td><%= number_to_currency(p.adyen_amount_cents.to_i / 100.0, unit: p.currency) %></td>
-            <td><span class="badge <%= { matched:"badge-success", partial:"badge-muted", conflict:"badge-error", unmatched:"badge-muted" }[p.status] %>"><%= p.status %></span></td>
+            <td>
+              <% if transactions.present? %>
+                <div data-controller="modal">
+                  <button type="button" class="btn btn-secondary" data-action="modal#open">
+                    View transactions
+                  </button>
+                  <dialog data-modal-target="dialog" data-action="click->modal#backdrop" class="modal" aria-modal="true" role="dialog" aria-labelledby="<%= heading_id %>">
+                    <div class="modal__header">
+                      <h3 class="modal__title" id="<%= heading_id %>">Transactions for payout <span class="font-mono text-xs"><%= p.adyen_payout_id %></span></h3>
+                      <button type="button" class="btn btn-ghost" data-action="modal#close">Close</button>
+                    </div>
+                    <div class="modal__body">
+                      <p class="modal__meta">
+                        <% if period_start %>
+                          Captures booked after <span class="font-mono"><%= period_start %></span> and up to <span class="font-mono"><%= period_end %></span>.
+                        <% else %>
+                          Captures booked up to <span class="font-mono"><%= period_end %></span>.
+                        <% end %>
+                      </p>
+                      <div class="table-wrap">
+                        <table class="table">
+                          <thead>
+                            <tr><th class="w-32">Value date</th><th>Reference</th><th class="text-right">Amount</th></tr>
+                          </thead>
+                          <tbody>
+                            <% transactions.each do |tx| %>
+                              <tr>
+                                <td class="font-mono text-xs"><%= tx[:date] %></td>
+                                <td class="font-mono text-xs"><%= tx[:reference].presence || "—" %></td>
+                                <td class="text-right"><%= number_to_currency(tx[:amount_cents].to_i / 100.0, unit: p.currency) %></td>
+                              </tr>
+                            <% end %>
+                          </tbody>
+                          <tfoot>
+                            <tr>
+                              <th colspan="2" class="text-right">Transaction total</th>
+                              <td class="text-right"><%= number_to_currency(transactions_total / 100.0, unit: p.currency) %></td>
+                            </tr>
+                            <tr>
+                              <th colspan="2" class="text-right">Payout amount</th>
+                              <td class="text-right"><%= number_to_currency(p.adyen_amount_cents.to_i.abs / 100.0, unit: p.currency) %></td>
+                            </tr>
+                            <% difference = (p.adyen_amount_cents.to_i.abs - transactions_total) %>
+                            <% if difference != 0 %>
+                              <tr>
+                                <th colspan="2" class="text-right">Difference</th>
+                                <td class="text-right"><%= number_to_currency(difference / 100.0, unit: p.currency) %></td>
+                              </tr>
+                            <% end %>
+                          </tfoot>
+                        </table>
+                      </div>
+                    </div>
+                  </dialog>
+                </div>
+              <% else %>
+                <span class="badge <%= { matched:"badge-success", partial:"badge-muted", conflict:"badge-error", unmatched:"badge-muted" }[p.status] %>"><%= p.status %></span>
+              <% end %>
+            </td>
           </tr>
         <% end %>
         </tbody>

--- a/test/services/recon/payout_matcher_test.rb
+++ b/test/services/recon/payout_matcher_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+module Recon
+  class PayoutMatcherTest < ActiveSupport::TestCase
+    setup do
+      @credential = AdyenCredential.create!(label: "Test", auth_method: :password)
+      @statement_file = ReportFile.create!(
+        adyen_credential: @credential,
+        kind: :statement,
+        reported_on: Date.new(2025, 8, 1),
+        currency: "USD"
+      )
+      @payout_file = ReportFile.create!(
+        adyen_credential: @credential,
+        kind: :statement,
+        reported_on: Date.new(2025, 8, 1),
+        currency: "USD"
+      )
+    end
+
+    test "stores capture transactions between payouts" do
+      previous_payout_date = Date.new(2025, 8, 3)
+      payout_date          = Date.new(2025, 8, 5)
+
+      Payout.create!(
+        bank_transfer_id: "PREV-1",
+        booked_on: previous_payout_date,
+        currency: "USD",
+        amount_minor: -50_000,
+        payout_ref: "PREV",
+        source_report_file: @payout_file
+      )
+
+      current_payout = Payout.create!(
+        bank_transfer_id: "CURR-1",
+        booked_on: payout_date,
+        currency: "USD",
+        amount_minor: -30_000,
+        payout_ref: "CURR",
+        source_report_file: @payout_file
+      )
+
+      StatementLine.create!(
+        report_file: @statement_file,
+        line_no: 1,
+        occurred_on: previous_payout_date - 1,
+        book_date: previous_payout_date - 1,
+        category: "payment",
+        type: "capture",
+        amount_minor: 10_000,
+        currency: "USD",
+        reference: "IGNORED-1"
+      )
+
+      StatementLine.create!(
+        report_file: @statement_file,
+        line_no: 2,
+        occurred_on: previous_payout_date + 1,
+        book_date: previous_payout_date + 1,
+        category: "payment",
+        type: "capture",
+        amount_minor: 12_000,
+        currency: "USD",
+        reference: "MATCH-1"
+      )
+
+      StatementLine.create!(
+        report_file: @statement_file,
+        line_no: 3,
+        occurred_on: payout_date,
+        book_date: payout_date,
+        category: "platformPayment",
+        type: "Capture",
+        amount_minor: 18_000,
+        currency: "USD",
+        reference: "MATCH-2"
+      )
+
+      Recon::PayoutMatcher.new(account_scope: nil, bank_lines: [], date: payout_date, currency: "USD").call
+
+      match = PayoutMatch.find_by!(adyen_payout_id: "CURR-1")
+      assert_equal "matched", match.status
+
+      details = match.details.deep_symbolize_keys
+      assert_equal previous_payout_date.to_s, details[:transactions_period_start]
+
+      transactions = details[:transactions]
+      assert_equal 2, transactions.length
+      assert_equal ["MATCH-1", "MATCH-2"], transactions.map { |tx| tx[:reference] }
+
+      assert_equal 30_000, details[:transactions_total_cents]
+      assert_equal 30_000, match.adyen_amount_cents.abs
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- compute capture transactions between payouts and persist them in `PayoutMatch`
- surface a modal on the reconciliation payout table to review the contributing transactions
- add styling, Stimulus controller, and tests covering the transaction matching behavior

## Testing
- bin/rails test *(fails: missing gems because bundle install is blocked by 403 Forbidden from rubygems)*

------
https://chatgpt.com/codex/tasks/task_e_68cf437a5b348321a7e7d1bf977185d4