### PR TITLE
Constrain payout capture window to value date range

### DIFF
--- a/app/services/recon/payout_matcher.rb
+++ b/app/services/recon/payout_matcher.rb
@@ -82,7 +82,7 @@ module Recon
 
       previous_date = previous_payout_date(payout_date:, currency:)
 
-      relation = relation.where("statement_lines.#{Sources::Config::SL_BOOK_DATE} <= ?", payout_date)
+      relation = relation.where("statement_lines.#{Sources::Config::SL_BOOK_DATE} < ?", payout_date)
       relation = relation.where("statement_lines.#{Sources::Config::SL_BOOK_DATE} > ?", previous_date) if previous_date
 
       rows = relation.order("statement_lines.#{Sources::Config::SL_BOOK_DATE} ASC, statement_lines.line_no ASC")
@@ -90,6 +90,7 @@ module Recon
 
       transactions = rows.map do |date, reference, amount|
         {
+          value_date: date&.to_s,
           date: date&.to_s,
           reference: reference,
           amount_cents: amount.to_i

--- a/app/views/reconciliations/show.html.erb
+++ b/app/views/reconciliations/show.html.erb
@@ -116,9 +116,9 @@
                     <div class="modal__body">
                       <p class="modal__meta">
                         <% if period_start %>
-                          Captures booked after <span class="font-mono"><%= period_start %></span> and up to <span class="font-mono"><%= period_end %></span>.
+                          Captures booked after <span class="font-mono"><%= period_start %></span> and before <span class="font-mono"><%= period_end %></span>.
                         <% else %>
-                          Captures booked up to <span class="font-mono"><%= period_end %></span>.
+                          Captures booked before <span class="font-mono"><%= period_end %></span>.
                         <% end %>
                       </p>
                       <div class="table-wrap">
@@ -129,7 +129,7 @@
                           <tbody>
                             <% transactions.each do |tx| %>
                               <tr>
-                                <td class="font-mono text-xs"><%= tx[:date] %></td>
+                                <td class="font-mono text-xs"><%= tx[:value_date] || tx[:date] %></td>
                                 <td class="font-mono text-xs"><%= tx[:reference].presence || "—" %></td>
                                 <td class="text-right"><%= number_to_currency(tx[:amount_cents].to_i / 100.0, unit: p.currency) %></td>
                               </tr>

--- a/test/services/recon/payout_matcher_test.rb
+++ b/test/services/recon/payout_matcher_test.rb
@@ -68,12 +68,24 @@ module Recon
         report_file: @statement_file,
         line_no: 3,
         occurred_on: payout_date,
-        book_date: payout_date,
+        book_date: payout_date - 1,
         category: "platformPayment",
         type: "Capture",
         amount_minor: 18_000,
         currency: "USD",
         reference: "MATCH-2"
+      )
+
+      StatementLine.create!(
+        report_file: @statement_file,
+        line_no: 4,
+        occurred_on: payout_date,
+        book_date: payout_date,
+        category: "platformPayment",
+        type: "Capture",
+        amount_minor: 5_000,
+        currency: "USD",
+        reference: "IGNORED-2"
       )
 
       Recon::PayoutMatcher.new(account_scope: nil, bank_lines: [], date: payout_date, currency: "USD").call
@@ -87,6 +99,8 @@ module Recon
       transactions = details[:transactions]
       assert_equal 2, transactions.length
       assert_equal ["MATCH-1", "MATCH-2"], transactions.map { |tx| tx[:reference] }
+      assert_equal [previous_payout_date + 1, payout_date - 1].map(&:to_s),
+                   transactions.map { |tx| tx[:value_date] }
 
       assert_equal 30_000, details[:transactions_total_cents]
       assert_equal 30_000, match.adyen_amount_cents.abs


### PR DESCRIPTION
## Summary
- require capture transactions to fall strictly between the previous and current payout value dates when matching
- surface the capture value date in the reconciliation modal and update the helper text
- adjust reconciliation payout matcher test coverage to reflect the stricter window and verify value dates

## Testing
- ⚠️ `bin/rails test test/services/recon/payout_matcher_test.rb` *(fails: missing gems, bundle install blocked by 403 from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cf48539fa08321b0ead4ad0d6e112d