### PR TITLE
Scope payouts by balance account and account holder

### DIFF
--- a/app/controllers/reconciliations_controller.rb
+++ b/app/controllers/reconciliations_controller.rb
@@ -42,7 +42,8 @@ class ReconciliationsController < ApplicationController
           resolved_currency = resolved_currency&.upcase
           next unless resolved_currency && currency_filter.include?(resolved_currency)
 
-          scope = payout.source_report_file&.account_code.presence
+          source_file = payout.source_report_file
+          scope = Sources::ScopeKey.build(source_file&.account_code, source_file&.account_id)
           payout_combos << [scope, payout.booked_on, resolved_currency]
         end
       end

--- a/app/services/parse/reconciliation_enqueuer.rb
+++ b/app/services/parse/reconciliation_enqueuer.rb
@@ -7,7 +7,7 @@ module Parse
     def enqueue(report_file:, day_currency_map:)
       return if day_currency_map.blank?
 
-      scope = report_file.account_code.presence
+      scope = Sources::ScopeKey.build(report_file.account_code, report_file.account_id)
       seen = Set.new
 
       day_currency_map.each do |day, currencies|

--- a/app/services/recon/build_daily.rb
+++ b/app/services/recon/build_daily.rb
@@ -24,8 +24,9 @@ module Recon
                           report_files.#{Sources::Config::RF_REPORTED_ON}
                         ) = ?
                       SQL
-                      .distinct.pluck(Sources::Config::RF_SCOPE)
-                      .map { |scope| scope.presence }
+                      .distinct
+                      .pluck(Sources::Config::RF_SCOPE, "report_files.account_id")
+                      .map { |code, account_id| Sources::ScopeKey.build(code, account_id) }
         end
         if Sources::Config::StatementLine
           scopes |= ReportFile
@@ -37,8 +38,9 @@ module Recon
                           report_files.#{Sources::Config::RF_REPORTED_ON}
                         ) = ?
                       SQL
-                      .distinct.pluck(Sources::Config::RF_SCOPE)
-                      .map { |scope| scope.presence }
+                      .distinct
+                      .pluck(Sources::Config::RF_SCOPE, "report_files.account_id")
+                      .map { |code, account_id| Sources::ScopeKey.build(code, account_id) }
         end
         scopes = scopes.map { |scope| scope.presence }.uniq
         scopes.unshift(nil) unless scopes.include?(nil)  # ← ensure we compute the nil scope

--- a/app/services/sources/payouts.rb
+++ b/app/services/sources/payouts.rb
@@ -11,11 +11,14 @@ module Sources
 
       relation = model.left_joins(:source_report_file)
 
-      relation = if scope.nil?
-                   relation.where("COALESCE(report_files.account_code, '') = ''")
-                 else
-                   relation.where("report_files.account_code = ?", scope)
-                 end
+      account_code, account_holder = Sources::ScopeKey.parse(scope)
+      if account_code.nil? && account_holder.nil?
+        relation = relation.where("COALESCE(report_files.account_code, '') = ''")
+                             .where("COALESCE(report_files.account_id, '') = ''")
+      else
+        relation = relation.where("report_files.account_code = ?", account_code) if account_code
+        relation = relation.where("report_files.account_id = ?", account_holder) if account_holder
+      end
 
       relation = relation.where(booked_on: date) if date
       if currency.present?

--- a/app/services/sources/scope_key.rb
+++ b/app/services/sources/scope_key.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Sources
+  module ScopeKey
+    SEPARATOR = "::"
+    HOLDER_PREFIX = "holder"
+
+    module_function
+
+    def build(account_code, account_id)
+      code = normalize_part(account_code)
+      holder = normalize_part(account_id)
+
+      return nil if code.nil? && holder.nil?
+
+      if code && holder
+        "#{code}#{SEPARATOR}#{holder}"
+      elsif code
+        code
+      else
+        "#{HOLDER_PREFIX}#{SEPARATOR}#{holder}"
+      end
+    end
+
+    def parse(scope)
+      return [nil, nil] if scope.nil?
+
+      str = scope.to_s.strip
+      return [nil, nil] if str.empty?
+
+      if str.start_with?("#{HOLDER_PREFIX}#{SEPARATOR}")
+        [nil, normalize_part(str.split(SEPARATOR, 2)[1])]
+      elsif str.include?(SEPARATOR)
+        code, holder = str.split(SEPARATOR, 2)
+        [normalize_part(code), normalize_part(holder)]
+      else
+        [normalize_part(str), nil]
+      end
+    end
+
+    def normalize_part(value)
+      str = value.to_s.strip
+      str.present? ? str : nil
+    end
+    private_class_method :normalize_part
+  end
+end

--- a/app/services/sources/statement.rb
+++ b/app/services/sources/statement.rb
@@ -12,16 +12,23 @@ module Sources
     def self.capture_scope(scope, date, currency)
       rf_kind = ReportFile.kinds[C::KIND_STATEMENT] # integer enum
 
-      C::StatementLine
-        .joins("INNER JOIN report_files rf ON rf.id = statement_lines.#{C::SL_FILE_ID}")
-        .where("rf.#{C::RF_KIND} = ?", rf_kind)
-        .yield_self { |rel|
-          if scope.nil?
-            rel.where("rf.#{C::RF_SCOPE} IS NULL")
-          else
-            rel.where("rf.#{C::RF_SCOPE} = ?", scope)
-          end
-        }
+      account_code, account_holder = Sources::ScopeKey.parse(scope)
+
+      base = C::StatementLine
+               .joins("INNER JOIN report_files rf ON rf.id = statement_lines.#{C::SL_FILE_ID}")
+               .where("rf.#{C::RF_KIND} = ?", rf_kind)
+
+      base = if account_code.nil? && account_holder.nil?
+               base.where("COALESCE(rf.#{C::RF_SCOPE}, '') = ''")
+                   .where("COALESCE(rf.account_id, '') = ''")
+             else
+               scoped = base
+               scoped = scoped.where("rf.#{C::RF_SCOPE} = ?", account_code) if account_code
+               scoped = scoped.where("rf.account_id = ?", account_holder) if account_holder
+               scoped
+             end
+
+      base
         .where("statement_lines.#{C::SL_BOOK_DATE} = ?", date)
         .where(<<~SQL, currency, currency)
           (statement_lines.#{C::SL_CURRENCY} = ?


### PR DESCRIPTION
## Summary
- introduce Sources::ScopeKey to normalize combined balance-account/account-holder scopes
- update reconciliation builders, sources, and payout matcher to apply both account code and account holder filters
- ensure payout lookup in the UI uses the same composite scope key

## Testing
- bundle exec rake test *(fails: missing native gems in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4d006d7083219c88a234778d5aad