### PR TITLE
Normalize payout currencies when matching

### DIFF
--- a/app/services/sources/payouts.rb
+++ b/app/services/sources/payouts.rb
@@ -27,6 +27,8 @@ module Sources
 
       relation.find_each.map do |p|
         resolved_currency = p.currency.presence || p.source_report_file&.currency
+        resolved_currency = resolved_currency&.to_s&.strip
+        resolved_currency = resolved_currency.present? ? resolved_currency.upcase : nil
         {
           id: p.bank_transfer_id.presence || p.payout_ref.presence || "payout-#{p.id}",
           date: p.booked_on,


### PR DESCRIPTION
## Summary
- normalize currencies from Adyen payouts and bank statement lines before attempting matches
- ensure payout records expose upper-case currencies for downstream consumers
- cover the normalization behaviour with a dedicated payout matcher test

## Testing
- bin/rails test test/services/recon/payout_matcher_test.rb *(fails: missing gems; bundler could not fetch dependencies due to 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68cf51d959188321acca6dce7cd475b2