### PR TITLE
Normalize currency filter for payout queries

### DIFF
--- a/app/services/sources/payouts.rb
+++ b/app/services/sources/payouts.rb
@@ -22,7 +22,11 @@ module Sources
 
       relation = relation.where(booked_on: date) if date
       if currency.present?
-        relation = relation.where("COALESCE(payouts.currency, report_files.currency) = ?", currency)
+        normalized_currency = currency.to_s.strip.upcase
+        relation = relation.where(
+          "UPPER(COALESCE(payouts.currency, report_files.currency)) = ?",
+          normalized_currency
+        )
       end
 
       relation.find_each.map do |p|


### PR DESCRIPTION
## Summary
- compare payout currency filters in a case-insensitive way so lower case values are matched

## Testing
- bin/rails test test/services/recon/payout_matcher_test.rb *(fails: missing gems, bundler install blocked by 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d076491718832195a0b4b68614d3fb